### PR TITLE
fix: repair dashboard entrypoint and stop predict no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ Access the dashboard at `http://localhost:8050` to:
 # Train a model
 python -m src.cli train --platform linkedin --content-type no_video --model-type xgboost
 
-# Make predictions
+# Make predictions (not implemented yet — exits non-zero with a clear error;
+# use `train` to build models in the meantime)
 python -m src.cli predict --platform linkedin --content-type no_video --date 2023-12-01
 
 # Analyze data

--- a/dash_app/app.py
+++ b/dash_app/app.py
@@ -479,7 +479,7 @@ def analyze_cross_platform(n_clicks):
         return dbc.Alert(f"Error: {str(e)}", color="danger")
 
 if __name__ == "__main__":
-    app.run_server(
+    app.run(
         debug=os.getenv("DASHBOARD_DEBUG", "true").lower() == "true",
         host=os.getenv("DASHBOARD_HOST", "0.0.0.0"),
         port=int(os.getenv("DASHBOARD_PORT", 8050))

--- a/src/cli.py
+++ b/src/cli.py
@@ -135,17 +135,24 @@ def predict(args):
         if not model_file.exists():
             logger.error(f"Model not found: {model_file}")
             return 1
-        
-        # Load model (this would need to be implemented in the base model)
-        logger.info(f"Loading model from {model_file}")
-        # model = BaseModel.load_model(str(model_file))
-        
-        # For now, just print a message
-        logger.info(f"Prediction for {args.platform} {args.content_type} on {args.date}")
-        logger.info("Prediction functionality to be implemented")
-        
-        return 0
-        
+
+        # NOTE: end-to-end prediction is not implemented yet. Producing a
+        # prediction requires loading the trained model AND building the
+        # date-keyed feature row for args.date from Supabase via DataLoader +
+        # FeatureEngineer (the same pipeline train_model uses). Until that path
+        # exists, fail loudly with a non-zero exit code instead of logging a
+        # success message and returning 0 — a silent no-op hides the gap from
+        # callers and CI. See GitHub issue #3.
+        logger.error(
+            "❌ Prediction is not implemented yet "
+            f"(requested: platform={args.platform}, "
+            f"content_type={args.content_type}, date={args.date}). "
+            f"A trained model exists at {model_file}, but the feature-row "
+            "construction for a given date is not wired up. Use the `train` "
+            "command to build models; `predict` will be enabled in a future change."
+        )
+        return 1
+
     except Exception as e:
         logger.error(f"Error making prediction: {e}")
         return 1


### PR DESCRIPTION
## Summary

Fixes the two user-facing entrypoint bugs from the `/codebase-audit` sweep in #3.

1. **`dash_app/app.py:482`** — the dashboard entrypoint called `app.run_server(...)`, which was deprecated then removed in Dash 2.16+. `requirements.txt` floors `dash>=2.14.0`, so a fresh install pulls a current Dash (locally 4.1.0) where `Dash` has no `run_server` attribute, and the dashboard raised `AttributeError` on startup. Renamed to `app.run(...)` (identical kwargs — `debug`/`host`/`port` are unchanged on the new API).

2. **`src/cli.py:124-151`** — the `predict` subcommand never loaded or invoked a model: it logged "Prediction functionality to be implemented" and `return 0`, reporting success while doing nothing, so callers/CI could not detect the no-op. **Took the issue's documented safe stop-gap** (not the full implementation): `predict` now logs a clear ERROR-level "not implemented" message and returns a non-zero exit code.

   **Why the stop-gap over a full implementation:** producing a real prediction needs both a trained artifact *and* a date-keyed feature row built for `--date` from Supabase via `DataLoader` + `FeatureEngineer` (the same pipeline `train` uses). `BaseModel.load_model` is real and usable, but there is no trained-model artifact and no offline fixture for the date→feature-row step, so a full load+predict path could not be validated within a bounded YOLO run. Shipping an unvalidated half-implementation was explicitly out of scope; the stop-gap is fully validatable and removes the silent-success failure mode.

`README.md` updated to flag the `predict` CLI example as not-yet-implemented.

## Validation

- **Reproduction (finding 1):** confirmed installed Dash is `4.1.0`; `hasattr(dash.Dash, "run_server")` is `False`, `hasattr(dash.Dash, "run")` is `True` — so `run_server` would crash on a fresh install.
- **Syntax gate:** `python -m py_compile dash_app/app.py src/cli.py` → OK.
- **Tests:** `python -m pytest` → `1 failed, 6 passed, 1 error`. The one failure (`test_create_platform_dataset`, a feature-engineering data-shape test) and one error (`test_connection`, requires live Supabase credentials) are **pre-existing on `main`** and unrelated to this change — verified by running them on `main` before branching. No new failures, no regressions.
- **Behavioural — finding 1:** booted `python dash_app/app.py` on Dash 4.1.0 → "Dash is running on ...", served `HTTP 200` with real Dash markup, **zero** AttributeError in the boot log.
- **Behavioural — finding 2:** ran `python -m src.cli predict --platform linkedin --content-type no_video --model-type xgboost --date 2023-12-01`. With a model artifact present (so the missing-model guard is bypassed) the new not-implemented branch logged a clear ERROR and exited **1** (previously this exact path exited 0). With no artifact, the existing missing-model guard exits 1.
- **Sanity sweep:** `git diff main...HEAD` touches only `dash_app/app.py`, `src/cli.py`, `README.md` — scoped hunks only, no dependency bumps, no removed tests, no weakened assertions.

Closes #3
