### PR TITLE
fix: stop pytest collecting Supabase diagnostic and fix create_platform_dataset test contract

### DIFF
--- a/HOW-TO.md
+++ b/HOW-TO.md
@@ -20,7 +20,7 @@ This document is your comprehensive guide to learning data science by building a
 
 | Component | Status | Purpose | Test Script |
 |-----------|--------|---------|-------------|
-| **Data Layer** | ✅ Complete | Connect to Supabase database | `test_supabase_connection.py` |
+| **Data Layer** | ✅ Complete | Connect to Supabase database | `tools/supabase_connection_check.py` |
 | **Feature Engineering** | ✅ Complete | Transform raw data into features | `tests/test_feature_engineering.py` |
 | **Machine Learning** | 🔄 Next Step | Train and evaluate models | Coming in Step 3 |
 | **API Layer** | 🔄 Coming Soon | Make predictions available | Coming in Step 4 |
@@ -145,7 +145,7 @@ pip install python-dotenv supabase pandas
 
 **Step 2: Run the connection test**
 ```bash
-python test_supabase_connection.py
+python tools/supabase_connection_check.py
 ```
 
 **What the test does:**

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -78,21 +78,34 @@ class TestDataLoader:
         assert 'day_of_week' in processed_df.columns
     
     def test_create_platform_dataset(self):
-        """Test platform dataset creation."""
-        # Mock data
+        """Test platform dataset creation.
+
+        ``create_platform_dataset`` consumes *preprocessed* frames (it selects
+        the temporal columns ``day_of_week``/``month``/``quarter``/``year``/
+        ``is_weekend`` and the ``follower_growth_*`` columns that only
+        ``preprocess_*`` produce), exactly as the real pipeline does in
+        ``cli.py``. Feed it raw frames through the preprocessing step rather
+        than hand-rolling half-preprocessed mocks.
+        """
+        # Raw mock data, as it would arrive from Supabase
         posts_df = pd.DataFrame({
             'date': ['2023-01-01', '2023-01-02'],
-            'engagement_linkedin_no_video': [100, 150],
-            'engagement_rate_linkedin_no_video': [0.1, 0.15]
+            'num_likes_linkedin_no_video': [85, 130],
+            'num_comments_linkedin_no_video': [10, 15],
+            'num_reshares_linkedin_no_video': [5, 5]
         })
         profile_df = pd.DataFrame({
             'date': ['2023-01-01', '2023-01-02'],
             'num_followers_linkedin': [1000, 1050]
         })
-        
+
+        # Preprocess first, mirroring the real pipeline contract
+        posts_df = self.data_loader.preprocess_posts_data(posts_df)
+        profile_df = self.data_loader.preprocess_profile_data(profile_df)
+
         # Test
         platform_df = self.data_loader.create_platform_dataset('linkedin', posts_df, profile_df)
-        
+
         assert len(platform_df) == 2
         assert 'engagement_linkedin_no_video' in platform_df.columns
         assert 'num_followers_linkedin' in platform_df.columns

--- a/tools/supabase_connection_check.py
+++ b/tools/supabase_connection_check.py
@@ -36,7 +36,7 @@ def load_environment():
     
     return url, key, service_key
 
-def test_connection(url: str, key: str) -> Client:
+def check_connection(url: str, key: str) -> Client:
     """Test Supabase connection"""
     try:
         print(f"🔌 Connecting to Supabase...")
@@ -105,7 +105,7 @@ def main():
         sys.exit(1)
     
     # Test connection
-    client = test_connection(url, key)
+    client = check_connection(url, key)
     if not client:
         sys.exit(1)
     


### PR DESCRIPTION
## Summary

Fixes the two pre-existing pytest reds on `main` from #12.

**Finding 1 — manual diagnostic mis-collected as a test.** `tests/test_supabase_connection.py` was a hand-run, live-credential Supabase diagnostic (with a `main()`), not a unit test. Its helper `test_connection(url, key)` carried the `test_` prefix, so pytest collected it and errored treating `url`/`key` as missing fixtures. Fixed by relocating it to `tools/supabase_connection_check.py` (it is a manual tool, not an automated test) and renaming the helper `test_connection` → `check_connection` (plus its call site in `main`). `HOW-TO.md` references updated to the new path. It remains runnable by hand: `python tools/supabase_connection_check.py`.

**Finding 2 — `create_platform_dataset` KeyError.** I fixed the **test**, not the function. `create_platform_dataset` documents its inputs as *preprocessed* frames and selects the temporal columns (`day_of_week`/`month`/`quarter`/`year`/`is_weekend`) and `follower_growth_*` columns that only `preprocess_posts_data`/`preprocess_profile_data` produce. The real pipeline (`src/cli.py` lines 53-54 → 64, and `src/api/prediction_api.py`) always calls it on preprocessed frames. The test was feeding raw/half-preprocessed mocks that lacked those columns, so `df[platform_cols]` raised `KeyError`. The function honours its contract; the test violated it. Fixed the fixture to build raw mocks and run them through `preprocess_*` first, mirroring the production call path. Assertions left unchanged (2 rows, `engagement_linkedin_no_video` + `num_followers_linkedin` present).

## Validation

- `& .\.venv\Scripts\python.exe -m py_compile tools/supabase_connection_check.py tests/test_data_loader.py` → OK.
- Baseline (before fix) on a clean branch: `1 failed, 6 passed, 1 error` — the `KeyError` and the collection error.
- After fix: full `& .\.venv\Scripts\python.exe -m pytest -q` → **`7 passed`**, 0 failures, 0 errors, 0 collection errors.
- `pytest --collect-only -q` confirms the Supabase diagnostic is no longer collected (7 items, all in `test_data_loader.py`); the diagnostic still parses and `check_connection` is present.
- `git diff main...HEAD` swept: scope limited to the rename, the two helper renames, the test-fixture fix, and two doc references. No dependency bumps, removed tests, weakened assertions, or `.gitignore` edits.

Closes #12
