### PR TITLE
fix: align venv docs and rename interactive scripts per CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ git clone https://github.com/yourusername/content-performance-predictor.git
 cd content-performance-predictor
 
 # Create virtual environment
-python -m venv venv
-source venv/bin/activate  # On Windows: venv\Scripts\activate
+python -m venv .venv
 
 # Install dependencies
-pip install -r requirements.txt
-pip install -e .
+.venv/bin/python -m pip install -r requirements.txt  # POSIX
+# .venv\Scripts\python.exe -m pip install -r requirements.txt  # Windows
+.venv/bin/python -m pip install -e .  # POSIX
+# .venv\Scripts\python.exe -m pip install -e .  # Windows
 ```
 
 ### 2. Environment Configuration
@@ -266,7 +267,7 @@ make format
 
 1. Add feature engineering logic in `src/features/feature_engineering.py`
 2. Update the `FeatureEngineer` class
-3. Add tests in `tests/test_feature_engineering.py`
+3. Add tests in `tests/demo_feature_engineering.py`
 
 ### Database Schema
 

--- a/tests/_sample_data.py
+++ b/tests/_sample_data.py
@@ -1,5 +1,5 @@
 """
-Shared test-data helpers used by test_feature_engineering.py and test_predictive_modeling.py.
+Shared test-data helpers used by demo_feature_engineering.py and demo_predictive_modeling.py.
 
 Extracted from both test scripts to eliminate duplication (issue #5).
 """

--- a/tests/demo_feature_engineering.py
+++ b/tests/demo_feature_engineering.py
@@ -16,7 +16,7 @@ Run this script to:
 - Test with your real social media data (if Supabase is connected)
 
 Usage:
-    python tests/test_feature_engineering.py
+    python tests/demo_feature_engineering.py
 
 Data Sources:
 - 📚 Sample Data: Creates realistic fake data (recommended for learning)

--- a/tests/demo_predictive_modeling.py
+++ b/tests/demo_predictive_modeling.py
@@ -17,7 +17,7 @@ Run this script to:
 - Test with your real social media data (if Supabase is connected)
 
 Usage:
-    python tests/test_predictive_modeling.py
+    python tests/demo_predictive_modeling.py
 
 Data Sources:
 - 📚 Sample Data: Creates realistic fake data (recommended for learning)


### PR DESCRIPTION
## Summary

- **README Quick Start (Fix 1):** Replaced the old venv-with-activation instructions (which used the bare env directory name) with .venv-based direct invocation — python -m venv .venv for setup, then .venv/bin/python -m pip install ... (POSIX) or .venv\Scripts\python.exe -m pip install ... (Windows). No activation step, matching the CLAUDE.md venv convention.
- **Interactive demo scripts (Fix 2):** Renamed 	ests/test_feature_engineering.py to 	ests/demo_feature_engineering.py and 	ests/test_predictive_modeling.py to 	ests/demo_predictive_modeling.py. These scripts call input() and carry no assertions so they must not be in the test_ namespace where pytest collects them. Updated the Usage: docstrings in both files and the _sample_data.py module docstring to reference the new filenames. Also updated the README Adding New Features section to point at the renamed file.

## Validation

- pytest --collect-only confirms 7 tests collected from test_data_loader.py only — no interactive demos are picked up.
- pytest reports 7 passed in 0.75s with no errors or warnings.

Closes #6