### PR TITLE
refactor: split oversized demo scripts and unify config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ make format
 
 1. Add feature engineering logic in `src/features/feature_engineering.py`
 2. Update the `FeatureEngineer` class
-3. Add tests in `tests/demo_feature_engineering.py`
+3. Add unit tests in `tests/test_feature_engineering.py` (pure logic) — `tests/demo_feature_engineering.py` is an interactive educational walkthrough, not a pytest suite
 
 ### Database Schema
 

--- a/src/features/feature_ranking.py
+++ b/src/features/feature_ranking.py
@@ -1,0 +1,248 @@
+"""Data-driven feature ranking utilities.
+
+Pure analytical helpers extracted from the feature-engineering demo so the
+ranking math can be imported, unit-tested, and reused independently of the
+educational walkthrough that narrates it.
+
+Each function takes a DataFrame plus the feature columns to consider and
+returns plain Python data structures (lists of dicts / lists of strings).
+None of them print — formatting and explanation live in the demo layer.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+# Weights for the composite score, in the order
+# (variance, completeness, distribution, complexity). Must sum to 1.0.
+COMPOSITE_WEIGHTS = (0.3, 0.25, 0.25, 0.2)
+
+# Substrings that mark a feature as "engineered" / more complex.
+_COMPLEXITY_PATTERNS = {
+    2: ("lag", "rolling", "trend", "ratio", "rate"),
+    1: ("sin", "cos", "cyclical", "scaled", "normalized"),
+}
+
+
+def _numeric_features(df: pd.DataFrame, feature_cols: List[str]) -> List[str]:
+    """Return the subset of ``feature_cols`` that are numeric in ``df``."""
+    return [
+        col
+        for col in feature_cols
+        if col in df.columns and pd.api.types.is_numeric_dtype(df[col])
+    ]
+
+
+def variance_analysis(df: pd.DataFrame, feature_cols: List[str]) -> List[Dict[str, Any]]:
+    """Rank numeric features by variance (higher = more information).
+
+    Returns a list of dicts with ``feature``, ``variance``, ``std``, ``mean``,
+    and ``cv`` (coefficient of variation), sorted by variance descending.
+    """
+    data: List[Dict[str, Any]] = []
+    for col in _numeric_features(df, feature_cols):
+        std = df[col].std()
+        mean = df[col].mean()
+        data.append(
+            {
+                "feature": col,
+                "variance": df[col].var(),
+                "std": std,
+                "mean": mean,
+                "cv": std / mean if mean != 0 else 0,
+            }
+        )
+    data.sort(key=lambda x: x["variance"], reverse=True)
+    return data
+
+
+def missing_value_analysis(df: pd.DataFrame, feature_cols: List[str]) -> List[Dict[str, Any]]:
+    """Rank features by data completeness (fewer missing = more reliable).
+
+    Returns dicts with ``feature``, ``missing_count``, ``missing_pct``,
+    sorted by missing percentage ascending.
+    """
+    n = len(df)
+    data: List[Dict[str, Any]] = []
+    for col in feature_cols:
+        if col not in df.columns:
+            continue
+        missing_count = int(df[col].isnull().sum())
+        data.append(
+            {
+                "feature": col,
+                "missing_count": missing_count,
+                "missing_pct": (missing_count / n) * 100 if n else 0.0,
+            }
+        )
+    data.sort(key=lambda x: x["missing_pct"])
+    return data
+
+
+def distribution_analysis(df: pd.DataFrame, feature_cols: List[str]) -> List[Dict[str, Any]]:
+    """Assess distribution quality of numeric features via IQR outliers.
+
+    Returns dicts with ``feature``, ``outlier_count``, ``outlier_pct``,
+    ``zero_variance``, ``unique_values`` (input order preserved).
+    """
+    n = len(df)
+    data: List[Dict[str, Any]] = []
+    for col in _numeric_features(df, feature_cols):
+        q1 = df[col].quantile(0.25)
+        q3 = df[col].quantile(0.75)
+        iqr = q3 - q1
+        outlier_count = len(df[(df[col] < q1 - 1.5 * iqr) | (df[col] > q3 + 1.5 * iqr)])
+        data.append(
+            {
+                "feature": col,
+                "outlier_count": outlier_count,
+                "outlier_pct": (outlier_count / n) * 100 if n else 0.0,
+                "zero_variance": bool(df[col].var() == 0),
+                "unique_values": int(df[col].nunique()),
+            }
+        )
+    return data
+
+
+def complexity_score(feature: str) -> int:
+    """Score a feature's engineering complexity from its name (0 = simplest)."""
+    name = feature.lower()
+    score = 0
+    for points, patterns in _COMPLEXITY_PATTERNS.items():
+        if any(word in name for word in patterns):
+            score += points
+    return score
+
+
+def complexity_level(score: int) -> str:
+    """Map a complexity score to a human-readable level."""
+    if score == 0:
+        return "Simple"
+    if score <= 2:
+        return "Medium"
+    return "Complex"
+
+
+def complexity_analysis(feature_cols: List[str]) -> List[Dict[str, Any]]:
+    """Rank features by name-derived complexity (simpler first).
+
+    Returns dicts with ``feature``, ``complexity_score``, ``complexity_level``,
+    sorted by score ascending.
+    """
+    data = [
+        {
+            "feature": col,
+            "complexity_score": complexity_score(col),
+            "complexity_level": complexity_level(complexity_score(col)),
+        }
+        for col in feature_cols
+    ]
+    data.sort(key=lambda x: x["complexity_score"])
+    return data
+
+
+def composite_scores(
+    df: pd.DataFrame,
+    feature_cols: List[str],
+    weights: Optional[tuple] = None,
+) -> List[Dict[str, Any]]:
+    """Compute a normalized, weighted composite ranking score per feature.
+
+    Combines the four analyses (variance, completeness, distribution,
+    complexity), normalizing each metric to a 0-1 scale (1 = best), then
+    applies ``weights`` (defaults to :data:`COMPOSITE_WEIGHTS`).
+
+    Returns dicts with the composite score, the normalized components, and the
+    raw inputs, sorted by composite score descending.
+    """
+    weights = weights or COMPOSITE_WEIGHTS
+
+    variance_data = variance_analysis(df, feature_cols)
+    missing_data = missing_value_analysis(df, feature_cols)
+    distribution_data = distribution_analysis(df, feature_cols)
+    complexity_data = complexity_analysis(feature_cols)
+
+    if not variance_data or not distribution_data:
+        return []
+
+    max_var = max(x["variance"] for x in variance_data)
+    max_missing = max((x["missing_pct"] for x in missing_data), default=0)
+    max_outliers = max(x["outlier_pct"] for x in distribution_data)
+    max_complexity = max(x["complexity_score"] for x in complexity_data)
+
+    by_feature_var = {x["feature"]: x for x in variance_data}
+    by_feature_missing = {x["feature"]: x for x in missing_data}
+    by_feature_dist = {x["feature"]: x for x in distribution_data}
+    by_feature_comp = {x["feature"]: x for x in complexity_data}
+
+    scores: List[Dict[str, Any]] = []
+    for col in feature_cols:
+        var_data = by_feature_var.get(col)
+        missing_item = by_feature_missing.get(col)
+        dist_data = by_feature_dist.get(col)
+        comp_data = by_feature_comp.get(col)
+
+        if not all([var_data, missing_item, dist_data, comp_data]):
+            continue
+
+        norm_variance = var_data["variance"] / max_var if max_var > 0 else 0
+        norm_completeness = (
+            1 - (missing_item["missing_pct"] / max_missing) if max_missing > 0 else 1
+        )
+        norm_distribution = (
+            1 - (dist_data["outlier_pct"] / max_outliers) if max_outliers > 0 else 1
+        )
+        norm_complexity = (
+            1 - (comp_data["complexity_score"] / max_complexity)
+            if max_complexity > 0
+            else 1
+        )
+
+        composite = (
+            norm_variance * weights[0]
+            + norm_completeness * weights[1]
+            + norm_distribution * weights[2]
+            + norm_complexity * weights[3]
+        )
+
+        scores.append(
+            {
+                "feature": col,
+                "composite_score": composite,
+                "norm_variance": norm_variance,
+                "norm_completeness": norm_completeness,
+                "norm_distribution": norm_distribution,
+                "norm_complexity": norm_complexity,
+                "raw_variance": var_data["variance"],
+                "raw_missing_pct": missing_item["missing_pct"],
+                "raw_outlier_pct": dist_data["outlier_pct"],
+                "raw_complexity": comp_data["complexity_score"],
+            }
+        )
+
+    scores.sort(key=lambda x: x["composite_score"], reverse=True)
+    return scores
+
+
+def target_correlations(
+    df: pd.DataFrame, target_col: str, feature_cols: List[str]
+) -> "pd.Series":
+    """Absolute-sorted correlations of numeric features with ``target_col``.
+
+    Returns an empty Series if the target is missing/non-numeric or there are
+    no numeric features.
+    """
+    if target_col not in df.columns or not pd.api.types.is_numeric_dtype(df[target_col]):
+        return pd.Series(dtype=float)
+
+    numeric = df[[c for c in feature_cols if c in df.columns]].select_dtypes(
+        include=[np.number]
+    )
+    if numeric.empty:
+        return pd.Series(dtype=float)
+
+    # ``DataFrame.corrwith(Series)`` correlates each column against the target;
+    # ``Series.corr`` only accepts another Series, so use corrwith here.
+    correlations = numeric.corrwith(df[target_col])
+    return correlations.sort_values(key=abs, ascending=False)

--- a/src/models/model_pipeline.py
+++ b/src/models/model_pipeline.py
@@ -1,0 +1,254 @@
+"""Reusable predictive-modeling pipeline helpers.
+
+Pure orchestration logic extracted from the predictive-modeling demo: building
+the standard model zoo, training/evaluating them, comparing performance, and
+the data-prep guards (leakage removal, target selection, missing-value
+imputation). Importable and unit-testable; the demo script narrates around
+these rather than re-implementing them.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .prediction_models import (
+    CatBoostModel,
+    EnsembleModel,
+    LightGBMModel,
+    LinearRegressionModel,
+    MLPModel,
+    RandomForestModel,
+    RidgeModel,
+    SVRModel,
+    XGBoostModel,
+)
+
+logger = logging.getLogger(__name__)
+
+# Feature-name fragments that indicate a column was derived from the target and
+# would leak it back into the model.
+_LEAKAGE_PATTERNS = ("_rolling_", "_lag_", "_scaled", "_rate", "_trend", "_diff")
+
+
+def remove_data_leakage_features(feature_cols: List[str], target_col: str) -> List[str]:
+    """Drop features derived from the target variable (data leakage).
+
+    Args:
+        feature_cols: Candidate feature column names.
+        target_col: The target column name.
+
+    Returns:
+        ``feature_cols`` with target-derived columns removed.
+    """
+    target_base = target_col.replace("_scaled", "")
+    leakage = [
+        col
+        for col in feature_cols
+        if target_base in col
+        and col != target_col
+        and any(pattern in col for pattern in _LEAKAGE_PATTERNS)
+    ]
+    return [col for col in feature_cols if col not in leakage]
+
+
+def find_leakage_features(feature_cols: List[str], target_col: str) -> List[str]:
+    """Return the target-derived (leaking) features without removing them."""
+    target_base = target_col.replace("_scaled", "")
+    return [
+        col
+        for col in feature_cols
+        if target_base in col
+        and col != target_col
+        and any(pattern in col for pattern in _LEAKAGE_PATTERNS)
+    ]
+
+
+def resolve_target_column(df: pd.DataFrame, target_col: str) -> str:
+    """Return ``target_col`` if present, else the best available fallback.
+
+    Fallback priority: engagement columns, then like columns, then comment
+    columns, then any non-date numeric column.
+
+    Raises:
+        ValueError: if no suitable numeric/target column exists.
+    """
+    if target_col in df.columns:
+        return target_col
+
+    candidates: List[str] = []
+    candidates += [c for c in df.columns if "engagement" in c.lower()]
+    candidates += [c for c in df.columns if "like" in c.lower()]
+    candidates += [c for c in df.columns if "comment" in c.lower()]
+    numeric = df.select_dtypes(include=[np.number]).columns.tolist()
+    candidates += [
+        c
+        for c in numeric
+        if not any(x in c.lower() for x in ("date", "day", "month", "year", "week", "quarter"))
+    ]
+
+    seen: set = set()
+    for col in candidates:
+        if col not in seen:
+            seen.add(col)
+            return col
+
+    raise ValueError(
+        f"No suitable target column found in data. Available columns: {list(df.columns)}"
+    )
+
+
+def prepare_modeling_data(
+    df: pd.DataFrame, target_col: str = "num_likes_linkedin_no_video"
+) -> Tuple[pd.DataFrame, pd.Series, List[str]]:
+    """Split a feature frame into (X, y, feature_cols) ready for modeling.
+
+    Resolves the target column, removes leakage features, and imputes missing
+    values (median for numeric, mode/empty-string for categorical).
+
+    Returns:
+        Tuple of (features DataFrame, target Series, feature column names).
+    """
+    target_col = resolve_target_column(df, target_col)
+
+    feature_cols = [col for col in df.columns if col not in ("date", target_col)]
+    feature_cols = remove_data_leakage_features(feature_cols, target_col)
+
+    X = df[feature_cols].copy()
+    y = df[target_col].copy()
+
+    for col in X.columns:
+        if X[col].dtype in ("int64", "float64"):
+            median_val = X[col].median()
+            X[col] = X[col].fillna(0 if pd.isna(median_val) else median_val)
+        else:
+            mode_val = X[col].mode()
+            if len(mode_val) > 0 and not pd.isna(mode_val.iloc[0]):
+                X[col] = X[col].fillna(mode_val.iloc[0])
+            else:
+                X[col] = X[col].fillna("")
+
+    y_median = y.median()
+    y = y.fillna(0 if pd.isna(y_median) else y_median)
+
+    return X, y, feature_cols
+
+
+def create_all_models(target_col: str, feature_cols: List[str]) -> Dict[str, Any]:
+    """Instantiate the standard model zoo (tree, linear, MLP, SVR, ensemble)."""
+    models: Dict[str, Any] = {
+        "random_forest": RandomForestModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            n_estimators=100,
+            max_depth=10,
+            random_state=42,
+        ),
+        "xgboost": XGBoostModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            n_estimators=100,
+            max_depth=6,
+            learning_rate=0.1,
+            random_state=42,
+        ),
+        "lightgbm": LightGBMModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            n_estimators=100,
+            max_depth=6,
+            learning_rate=0.1,
+            random_state=42,
+        ),
+        "catboost": CatBoostModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            iterations=100,
+            depth=6,
+            learning_rate=0.1,
+            random_state=42,
+        ),
+        "linear_regression": LinearRegressionModel(
+            target_column=target_col, feature_columns=feature_cols
+        ),
+        "ridge": RidgeModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            alpha=1.0,
+            random_state=42,
+        ),
+        "mlp": MLPModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            hidden_layer_sizes=(100, 50),
+            max_iter=1000,
+            random_state=42,
+        ),
+        "svr": SVRModel(
+            target_column=target_col,
+            feature_columns=feature_cols,
+            kernel="rbf",
+            C=1.0,
+            epsilon=0.1,
+        ),
+    }
+
+    ensemble = EnsembleModel(target_column=target_col, feature_columns=feature_cols)
+    for model_name in ("random_forest", "xgboost", "lightgbm"):
+        if model_name in models:
+            ensemble.add_model(models[model_name], weight=1.0)
+    models["ensemble"] = ensemble
+
+    return models
+
+
+def train_all_models(
+    models: Dict[str, Any], X: pd.DataFrame, y: pd.Series
+) -> Tuple[Dict[str, Any], List[str]]:
+    """Fit every model, returning (trained_models, failed_model_names)."""
+    trained: Dict[str, Any] = {}
+    failed: List[str] = []
+    for name, model in models.items():
+        try:
+            model.fit(X, y)
+            trained[name] = model
+        except Exception as exc:  # noqa: BLE001 - one bad model shouldn't abort
+            logger.warning("Error training %s: %s", name, exc)
+            failed.append(name)
+    return trained, failed
+
+
+def evaluate_all_models(
+    models: Dict[str, Any], X: pd.DataFrame, y: pd.Series
+) -> Dict[str, Dict[str, float]]:
+    """Evaluate each trained model, returning {name: metrics}."""
+    results: Dict[str, Dict[str, float]] = {}
+    for name, model in models.items():
+        try:
+            results[name] = model.evaluate(X, y)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Error evaluating %s: %s", name, exc)
+    return results
+
+
+def compare_model_performance(
+    evaluation_results: Dict[str, Dict[str, float]]
+) -> pd.DataFrame:
+    """Build a per-model comparison frame, sorted best-first.
+
+    Sorts by R² descending when available, else by MAE ascending. Returns an
+    empty DataFrame when there are no results.
+    """
+    if not evaluation_results:
+        return pd.DataFrame()
+
+    rows = [{"Model": name, **metrics} for name, metrics in evaluation_results.items()]
+    comparison = pd.DataFrame(rows)
+
+    if "r2" in comparison.columns:
+        comparison = comparison.sort_values("r2", ascending=False)
+    elif "mae" in comparison.columns:
+        comparison = comparison.sort_values("mae", ascending=True)
+
+    return comparison.reset_index(drop=True)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,144 +1,125 @@
 """Configuration utilities for the content performance predictor."""
 
 import os
+import re
 import yaml
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 from dotenv import load_dotenv
 
 load_dotenv()
 
+# Matches shell-style placeholders used in config.yaml:
+#   ${VAR}            -> value of VAR, or empty string if unset
+#   ${VAR:-default}   -> value of VAR, or "default" if unset
+_ENV_PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}")
+
+
+def _expand_env_placeholders(value: Any) -> Any:
+    """Recursively expand ``${VAR}`` / ``${VAR:-default}`` placeholders.
+
+    Walks dicts, lists, and strings loaded from YAML and substitutes
+    environment variables. This is the single mechanism by which config
+    defaults flow: ``config.yaml`` carries the shell-style syntax and the
+    values are resolved here at load time, so anything read via
+    ``Config.get(...)`` sees the expanded value rather than the literal
+    ``${VAR}`` placeholder string.
+
+    Args:
+        value: A value from the parsed YAML tree (dict, list, str, or scalar).
+
+    Returns:
+        The same structure with all string placeholders expanded.
+    """
+    if isinstance(value, dict):
+        return {k: _expand_env_placeholders(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_expand_env_placeholders(item) for item in value]
+    if isinstance(value, str):
+        def _replace(match: "re.Match[str]") -> str:
+            var_name, default = match.group(1), match.group(2)
+            return os.getenv(var_name, default if default is not None else "")
+
+        return _ENV_PLACEHOLDER.sub(_replace, value)
+    return value
+
 
 class Config:
     """Configuration manager for the application."""
-    
+
     def __init__(self, config_path: str = "config/config.yaml"):
         """
         Initialize configuration.
-        
+
         Args:
             config_path: Path to configuration file
         """
         self.config_path = config_path
         self.config = self._load_config()
-    
+
     def _load_config(self) -> Dict[str, Any]:
-        """Load configuration from file and environment variables."""
-        config = {}
-        
-        # Load YAML config if exists
+        """Load configuration from the YAML file, expanding env placeholders.
+
+        Defaults are expressed once, in ``config.yaml``, using the shell-style
+        ``${VAR:-default}`` syntax. They are resolved against the environment
+        here at load time — there is no second Python-side override mechanism.
+        """
+        config: Dict[str, Any] = {}
+
         if os.path.exists(self.config_path):
-            with open(self.config_path, 'r') as f:
-                config = yaml.safe_load(f)
-        
-        # Override with environment variables
-        config = self._override_with_env(config)
-        
-        return config
-    
-    def _override_with_env(self, config: Dict[str, Any]) -> Dict[str, Any]:
-        """Override configuration with environment variables."""
-        # Data configuration
-        if 'data' not in config:
-            config['data'] = {}
-        
-        config['data']['supabase'] = {
-            'url': os.getenv('SUPABASE_URL', config.get('data', {}).get('supabase', {}).get('url')),
-            'key': os.getenv('SUPABASE_KEY', config.get('data', {}).get('supabase', {}).get('key')),
-            'service_role_key': os.getenv('SUPABASE_SERVICE_ROLE_KEY', config.get('data', {}).get('supabase', {}).get('service_role_key'))
-        }
-        
-        # API configuration
-        if 'api' not in config:
-            config['api'] = {}
-        
-        config['api'].update({
-            'host': os.getenv('API_HOST', config.get('api', {}).get('host', '0.0.0.0')),
-            'port': int(os.getenv('API_PORT', config.get('api', {}).get('port', 8000))),
-            'reload': os.getenv('API_RELOAD', config.get('api', {}).get('reload', 'true')).lower() == 'true'
-        })
-        
-        # Dashboard configuration
-        if 'dashboard' not in config:
-            config['dashboard'] = {}
-        
-        config['dashboard'].update({
-            'host': os.getenv('DASHBOARD_HOST', config.get('dashboard', {}).get('host', '0.0.0.0')),
-            'port': int(os.getenv('DASHBOARD_PORT', config.get('dashboard', {}).get('port', 8050))),
-            'debug': os.getenv('DASHBOARD_DEBUG', config.get('dashboard', {}).get('debug', 'true')).lower() == 'true'
-        })
-        
-        # MLflow configuration
-        if 'mlflow' not in config:
-            config['mlflow'] = {}
-        
-        config['mlflow'].update({
-            'tracking_uri': os.getenv('MLFLOW_TRACKING_URI', config.get('mlflow', {}).get('tracking_uri', 'http://localhost:5000')),
-            'experiment_name': os.getenv('MLFLOW_EXPERIMENT_NAME', config.get('mlflow', {}).get('experiment_name', 'content-performance-predictor'))
-        })
-        
-        # Paths
-        if 'paths' not in config:
-            config['paths'] = {}
-        
-        config['paths'].update({
-            'models': os.getenv('MODEL_PATH', config.get('paths', {}).get('models', './models')),
-            'data': os.getenv('DATA_PATH', config.get('paths', {}).get('data', './data')),
-            'features': os.getenv('FEATURE_STORE_PATH', config.get('paths', {}).get('features', './data/features')),
-            'experiments': os.getenv('EXPERIMENT_PATH', config.get('paths', {}).get('experiments', './mlflow')),
-            'logs': os.getenv('LOG_PATH', config.get('paths', {}).get('logs', './logs'))
-        })
-        
-        return config
-    
+            with open(self.config_path, "r") as f:
+                config = yaml.safe_load(f) or {}
+
+        return _expand_env_placeholders(config)
+
     def get(self, key: str, default: Any = None) -> Any:
         """
         Get configuration value.
-        
+
         Args:
             key: Configuration key (dot notation supported)
             default: Default value if key not found
-            
+
         Returns:
             Configuration value
         """
-        keys = key.split('.')
-        value = self.config
-        
+        keys = key.split(".")
+        value: Any = self.config
+
         for k in keys:
             if isinstance(value, dict) and k in value:
                 value = value[k]
             else:
                 return default
-        
+
         return value
-    
+
     def get_supabase_config(self) -> Dict[str, str]:
         """Get Supabase configuration."""
-        return self.get('data.supabase', {})
-    
+        return self.get("data.supabase", {})
+
     def get_api_config(self) -> Dict[str, Any]:
         """Get API configuration."""
-        return self.get('api', {})
-    
+        return self.get("api", {})
+
     def get_dashboard_config(self) -> Dict[str, Any]:
         """Get dashboard configuration."""
-        return self.get('dashboard', {})
-    
+        return self.get("dashboard", {})
+
     def get_mlflow_config(self) -> Dict[str, str]:
         """Get MLflow configuration."""
-        return self.get('mlflow', {})
-    
+        return self.get("mlflow", {})
+
     def get_paths(self) -> Dict[str, str]:
         """Get paths configuration."""
-        return self.get('paths', {})
-    
+        return self.get("paths", {})
+
     def get_model_config(self) -> Dict[str, Any]:
         """Get model configuration."""
-        return self.get('models', {})
-    
+        return self.get("models", {})
+
     def get_feature_config(self) -> Dict[str, Any]:
         """Get feature engineering configuration."""
-        return self.get('features', {})
+        return self.get("features", {})
 
 
 # Global configuration instance

--- a/tests/demo_feature_engineering.py
+++ b/tests/demo_feature_engineering.py
@@ -1,1071 +1,301 @@
-"""
-🧪 Feature Engineering Test Script - Educational & Testing Purposes
+"""Feature Engineering Demo - educational walkthrough.
 
-This script demonstrates how the FeatureEngineer class works by:
-1. Choosing between sample data or real Supabase data
-2. Applying each feature engineering method step by step
-3. Showing the before/after state of the data
-4. Explaining what each feature represents
-5. Testing all functionality of the FeatureEngineer class
-
-Run this script to:
-- Test your FeatureEngineer implementation
-- Learn how each feature is created
-- See the impact of feature engineering on your data
-- Debug any issues with feature creation
-- Test with your real social media data (if Supabase is connected)
+A thin narration layer over ``src.features.feature_engineering`` and
+``src.features.feature_ranking``: it applies each feature-engineering method in
+turn and explains the result, then ranks the resulting features using the pure
+math in ``feature_ranking`` (unit-tested in ``tests/test_feature_ranking.py``).
+This script only orchestrates and explains; the reusable logic lives in ``src``.
 
 Usage:
     python tests/demo_feature_engineering.py
 
-Data Sources:
-- 📚 Sample Data: Creates realistic fake data (recommended for learning)
-- 🗄️ Real Data: Loads from your Supabase database (for production testing)
+Data sources:
+- Sample data: realistic fake data (recommended for learning)
+- Real data: loaded from Supabase (for production testing)
 """
 
-import sys
 import os
-import pandas as pd
-import numpy as np
+import sys
 import warnings
-warnings.filterwarnings('ignore')
+from typing import List
 
-# Add src to path so we can import our modules
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+import numpy as np
+import pandas as pd
+
+warnings.filterwarnings("ignore")
+
+# Add src to path so we can import our modules.
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from features.feature_engineering import FeatureEngineer
-from tests._sample_data import create_sample_data, load_real_data_from_supabase, choose_data_source
+from features.feature_ranking import (
+    complexity_analysis,
+    composite_scores,
+    distribution_analysis,
+    missing_value_analysis,
+    target_correlations,
+    variance_analysis,
+)
+from tests._sample_data import (
+    choose_data_source,
+    create_sample_data,
+    load_real_data_from_supabase,
+)
+
+
+def _show_new_columns(df_before, df_after, label):
+    """Print the columns added by a feature-engineering step."""
+    new_cols = [c for c in df_after.columns if c not in df_before.columns]
+    print(f"✨ {label}: added {len(new_cols)} features")
+    for col in new_cols:
+        print(f"   - {col}")
+    print()
 
 
 def demonstrate_temporal_features(df, fe):
-    """
-    🕐 Demonstrate temporal feature creation.
-    
-    Shows how dates are transformed into useful features for machine learning.
-    """
-    print("🕐 STEP 1: Creating Temporal Features")
+    """STEP 1: temporal features (dates → ML-friendly cyclical encodings)."""
+    print("🕐 STEP 1: Temporal Features")
     print("=" * 50)
-    
-    print("📅 Original date column (first 5 rows):")
-    print(df[['date']].head())
-    print()
-    
-    # Create temporal features
-    df_with_temporal = fe.create_temporal_features(df, 'date')
-    
-    print("✨ New temporal features created:")
-    temporal_cols = [col for col in df_with_temporal.columns if col not in df.columns]
-    print(f"   Added {len(temporal_cols)} new features:")
-    
-    for col in temporal_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of temporal features (first 5 rows):")
-    temporal_sample = df_with_temporal[['date', 'day_of_week', 'month', 'quarter', 'is_weekend', 'month_sin', 'month_cos']].head()
-    print(temporal_sample)
-    print()
-    
-    # Show cyclical encoding explanation
-    print("🔄 Cyclical Encoding Explanation:")
-    print("   - Regular encoding: month 1 and month 12 are far apart")
-    print("   - Sin/Cos encoding: month 1 and month 12 are close (circle)")
-    print("   - This helps models understand seasonal patterns better")
-    print()
-    
-    return df_with_temporal
+    result = fe.create_temporal_features(df, "date")
+    _show_new_columns(df, result, "Temporal features")
+    print("💡 Sin/Cos encoding keeps month 1 and month 12 close (cyclical).\n")
+    return result
 
 
 def demonstrate_lag_features(df, fe):
-    """
-    📈 Demonstrate lag feature creation.
-    
-    Shows how previous values help predict future performance.
-    """
-    print("📈 STEP 2: Creating Lag Features")
+    """STEP 2: lag features (past values predict future performance)."""
+    print("📈 STEP 2: Lag Features")
     print("=" * 50)
-    
-    # Use the actual column name from your Supabase schema
-    target_col = 'engagement_linkedin_no_video'
-    
+    target_col = "engagement_linkedin_no_video"
     if target_col not in df.columns:
-        print(f"⚠️  Column '{target_col}' not found. Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print("   Using first available numeric column instead.")
-        # Fallback to any numeric column that's not date
-        numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
-        numeric_cols = [col for col in numeric_cols if col != 'date']
-        if numeric_cols:
-            target_col = numeric_cols[0]
-        else:
-            print("❌ No suitable columns found for lag features")
+        numeric = [c for c in df.select_dtypes(include=[np.number]).columns if c != "date"]
+        if not numeric:
+            print("❌ No numeric column available for lag features\n")
             return df
-    
+        target_col = numeric[0]
     print(f"📊 Using column: {target_col}")
-    print("📊 Original engagement data (first 10 rows):")
-    print(df[['date', target_col]].head(10))
-    print()
-    
-    # Create lag features
-    df_with_lags = fe.create_lag_features(
-        df, 
-        target_cols=[target_col], 
-        lags=[1, 3, 7]
-    )
-    
-    print("✨ New lag features created:")
-    lag_cols = [col for col in df_with_lags.columns if col not in df.columns]
-    print(f"   Added {len(lag_cols)} new features:")
-    
-    for col in lag_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of lag features (first 10 rows):")
-    lag_sample_cols = ['date', target_col]
-    # Add available lag columns
-    for lag_col in [f'{target_col}_lag_1', f'{target_col}_lag_3', f'{target_col}_rolling_mean_7']:
-        if lag_col in df_with_lags.columns:
-            lag_sample_cols.append(lag_col)
-    
-    lag_sample = df_with_lags[lag_sample_cols].head(10)
-    print(lag_sample)
-    print()
-    
-    print("💡 Lag Feature Explanation:")
-    print("   - lag_1: Yesterday's engagement (immediate trend)")
-    print("   - lag_3: 3 days ago engagement (short-term pattern)")
-    print("   - lag_7: Week ago engagement (weekly pattern)")
-    print("   - rolling_mean: Average over the last N days (smoothing)")
-    print()
-    
-    return df_with_lags
+    result = fe.create_lag_features(df, target_cols=[target_col], lags=[1, 3, 7])
+    _show_new_columns(df, result, "Lag features")
+    print("💡 lag_N = value N days ago; rolling_mean smooths recent history.\n")
+    return result
 
 
 def demonstrate_engagement_features(df, fe):
-    """
-    🎯 Demonstrate engagement feature creation.
-    
-    Shows how engagement metrics are transformed into rates and ratios.
-    """
-    print("🎯 STEP 3: Creating Engagement Features")
+    """STEP 3: engagement features (rates and interaction ratios)."""
+    print("🎯 STEP 3: Engagement Features")
     print("=" * 50)
-    
-    # Use actual column names from your Supabase schema
-    engagement_cols = ['engagement_linkedin_no_video', 'num_followers_linkedin']
-    available_cols = [col for col in engagement_cols if col in df.columns]
-    
-    if not available_cols:
-        print("⚠️  Some expected columns not found. Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print("   Proceeding with available columns...")
-    
-    print("📊 Original engagement and follower data (first 5 rows):")
-    print(df[['date'] + available_cols].head())
-    print()
-    
-    # Create engagement features
-    df_with_engagement = fe.create_engagement_features(df, platforms=['linkedin', 'instagram'])
-    
-    print("✨ New engagement features created:")
-    engagement_new_cols = [col for col in df_with_engagement.columns if col not in df.columns]
-    print(f"   Added {len(engagement_new_cols)} new features:")
-    
-    for col in engagement_new_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of engagement features (first 5 rows):")
-    engagement_sample_cols = ['date'] + available_cols
-    # Add any new features that were created
-    for col in ['engagement_linkedin_no_video_rate', 'linkedin_no_video_comment_ratio']:
-        if col in df_with_engagement.columns:
-            engagement_sample_cols.append(col)
-    
-    available_sample_cols = [col for col in engagement_sample_cols if col in df_with_engagement.columns]
-    print(df_with_engagement[available_sample_cols].head())
-    print()
-    
-    print("💡 Engagement Feature Explanation:")
-    print("   - engagement_rate: Engagement per follower (normalized)")
-    print("   - comment_ratio: Comments per like (interaction quality)")
-    print("   - share_ratio: Shares per like (virality measure)")
-    print()
-    
-    return df_with_engagement
+    result = fe.create_engagement_features(df, platforms=["linkedin", "instagram"])
+    _show_new_columns(df, result, "Engagement features")
+    print("💡 engagement_rate normalizes by followers; ratios measure quality.\n")
+    return result
 
 
 def demonstrate_cross_platform_features(df, fe):
-    """
-    🌐 Demonstrate cross-platform feature creation.
-    
-    Shows how data from multiple platforms is combined and compared.
-    """
-    print("🌐 STEP 4: Creating Cross-Platform Features")
+    """STEP 4: cross-platform features (combine/compare across platforms)."""
+    print("🌐 STEP 4: Cross-Platform Features")
     print("=" * 50)
-    
-    # Use actual column names from your Supabase schema
-    platform_cols = ['engagement_linkedin_no_video', 'engagement_instagram_no_video', 
-                     'num_followers_linkedin', 'num_followers_instagram']
-    available_cols = [col for col in platform_cols if col in df.columns]
-    
-    if not available_cols:
-        print("⚠️  Some expected columns not found. Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print("   Proceeding with available columns...")
-    
-    print("📊 Original platform-specific data (first 5 rows):")
-    print(df[['date'] + available_cols].head())
-    print()
-    
-    # Create cross-platform features
-    df_with_cross = fe.create_cross_platform_features(df)
-    
-    print("✨ New cross-platform features created:")
-    cross_new_cols = [col for col in df_with_cross.columns if col not in df.columns]
-    print(f"   Added {len(cross_new_cols)} new features:")
-    
-    for col in cross_new_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of cross-platform features (first 5 rows):")
-    cross_sample_cols = ['date'] + available_cols
-    # Add any new features that were created
-    for col in ['total_engagement_no_video', 'avg_engagement_no_video', 'total_followers', 'linkedin_share_no_video']:
-        if col in df_with_cross.columns:
-            cross_sample_cols.append(col)
-    
-    available_sample_cols = [col for col in cross_sample_cols if col in df_with_cross.columns]
-    print(df_with_cross[available_sample_cols].head())
-    print()
-    
-    print("💡 Cross-Platform Feature Explanation:")
-    print("   - total_engagement: Sum across all platforms")
-    print("   - avg_engagement: Average across all platforms")
-    print("   - platform_share: Percentage of total engagement per platform")
-    print("   - total_followers: Combined audience size")
-    print()
-    
-    return df_with_cross
+    result = fe.create_cross_platform_features(df)
+    _show_new_columns(df, result, "Cross-platform features")
+    print("💡 total/avg engagement and per-platform share across platforms.\n")
+    return result
 
 
 def demonstrate_content_features(df, fe):
-    """
-    📝 Demonstrate content feature creation.
-    
-    Shows how text content is analyzed for NLP features.
-    """
-    print("📝 STEP 5: Creating Content Features")
+    """STEP 5: content features (NLP over any text column)."""
+    print("📝 STEP 5: Content Features")
     print("=" * 50)
-    
-    # Check if we have any text columns for content analysis
-    text_columns = [col for col in df.columns if 'text' in col.lower() or 'content' in col.lower()]
-    
+    text_columns = [c for c in df.columns if "text" in c.lower() or "content" in c.lower()]
     if not text_columns:
-        print("⚠️  No text content columns found in your data")
-        print("   Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print()
-        print("💡 Content Feature Explanation:")
-        print("   - Content features require text columns (e.g., post_text, content, description)")
-        print("   - Your current data has engagement metrics and follower counts")
-        print("   - To use content features, add text columns to your Supabase schema")
-        print()
+        print("⚠️  No text columns found; content features require a text column.\n")
         return df
-    
-    # Use the first available text column
     text_col = text_columns[0]
     print(f"📊 Using text column: {text_col}")
-    print("📊 Original text content (first 5 rows):")
-    print(df[['date', text_col]].head())
-    print()
-    
-    # Create content features
-    df_with_content = fe.create_content_features(df, text_col=text_col)
-    
-    print("✨ New content features created:")
-    content_new_cols = [col for col in df_with_content.columns if col not in df.columns]
-    print(f"   Added {len(content_new_cols)} new features:")
-    
-    for col in content_new_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of content features (first 5 rows):")
-    content_sample_cols = ['date', text_col]
-    # Add any new features that were created
-    for col in [f'{text_col}_length', f'{text_col}_word_count', f'{text_col}_sentiment', f'{text_col}_hashtag_count']:
-        if col in df_with_content.columns:
-            content_sample_cols.append(col)
-    
-    available_cols = [col for col in content_sample_cols if col in df_with_content.columns]
-    print(df_with_content[available_cols].head())
-    print()
-    
-    print("💡 Content Feature Explanation:")
-    print("   - text_length: Character count (engagement correlation)")
-    print("   - word_count: Word count (readability measure)")
-    print("   - sentiment: Positive/negative tone (-1 to +1)")
-    print("   - hashtag_count: Number of hashtags (discoverability)")
-    print("   - mention_count: Number of @mentions (networking)")
-    print()
-    
-    return df_with_content
+    result = fe.create_content_features(df, text_col=text_col)
+    _show_new_columns(df, result, "Content features")
+    print("💡 length, word_count, sentiment, hashtag/mention counts.\n")
+    return result
 
 
 def demonstrate_interaction_features(df, fe):
-    """
-    🤝 Demonstrate interaction feature creation.
-    
-    Shows how different types of interactions are combined and analyzed.
-    """
-    print("🤝 STEP 6: Creating Interaction Features")
+    """STEP 6: interaction features (combine likes/comments/reshares)."""
+    print("🤝 STEP 6: Interaction Features")
     print("=" * 50)
-    
-    # Use actual column names from your Supabase schema
-    interaction_cols = ['num_likes_linkedin_no_video', 'num_comments_linkedin_no_video', 'num_reshares_linkedin_no_video']
-    available_cols = [col for col in interaction_cols if col in df.columns]
-    
-    if not available_cols:
-        print("⚠️  Some expected columns not found. Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print("   Proceeding with available columns...")
-    
-    print("📊 Original interaction data (first 5 rows):")
-    print(df[['date'] + available_cols].head())
-    print()
-    
-    # Create interaction features
-    df_with_interactions = fe.create_interaction_features(df)
-    
-    print("✨ New interaction features created:")
-    interaction_new_cols = [col for col in df_with_interactions.columns if col not in df.columns]
-    print(f"   Added {len(interaction_new_cols)} new features:")
-    
-    for col in interaction_new_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of interaction features (first 5 rows):")
-    interaction_sample_cols = ['date'] + available_cols
-    # Add any new features that were created
-    for col in ['linkedin_no_video_comment_like_ratio', 'linkedin_no_video_total_interactions']:
-        if col in df_with_interactions.columns:
-            interaction_sample_cols.append(col)
-    
-    available_sample_cols = [col for col in interaction_sample_cols if col in df_with_interactions.columns]
-    print(df_with_interactions[available_sample_cols].head())
-    print()
-    
-    print("💡 Interaction Feature Explanation:")
-    print("   - comment_like_ratio: Comments per like (engagement quality)")
-    print("   - share_like_ratio: Shares per like (virality measure)")
-    print("   - total_interactions: Sum of all interaction types")
-    print()
-    
-    return df_with_interactions
+    result = fe.create_interaction_features(df)
+    _show_new_columns(df, result, "Interaction features")
+    print("💡 comment/like and share/like ratios, total interactions.\n")
+    return result
 
 
 def demonstrate_trend_features(df, fe):
-    """
-    📈 Demonstrate trend feature creation.
-    
-    Shows how time-based trends and patterns are captured.
-    """
-    print("📈 STEP 7: Creating Trend Features")
+    """STEP 7: trend features (momentum over rolling windows)."""
+    print("📈 STEP 7: Trend Features")
     print("=" * 50)
-    
-    # Use actual column name from your Supabase schema
-    target_col = 'engagement_linkedin_no_video'
-    
+    target_col = "engagement_linkedin_no_video"
     if target_col not in df.columns:
-        print(f"⚠️  Column '{target_col}' not found. Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print("   Using first available numeric column instead.")
-        # Fallback to any numeric column that's not date
-        numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
-        numeric_cols = [col for col in numeric_cols if col != 'date']
-        if numeric_cols:
-            target_col = numeric_cols[0]
-        else:
-            print("❌ No suitable columns found for trend features")
+        numeric = [c for c in df.select_dtypes(include=[np.number]).columns if c != "date"]
+        if not numeric:
+            print("❌ No numeric column available for trend features\n")
             return df
-    
+        target_col = numeric[0]
     print(f"📊 Using column: {target_col}")
-    print("📊 Original engagement data for trend analysis (first 10 rows):")
-    print(df[['date', target_col]].head(10))
-    print()
-    
-    # Create trend features
-    df_with_trends = fe.create_trend_features(df, window_sizes=[7, 14])
-    
-    print("✨ New trend features created:")
-    trend_new_cols = [col for col in df_with_trends.columns if col not in df.columns]
-    print(f"   Added {len(trend_new_cols)} new features:")
-    
-    for col in trend_new_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Sample of trend features (first 10 rows):")
-    trend_sample_cols = ['date', target_col]
-    # Add any new features that were created
-    for col in [f'{target_col}_trend_7', f'{target_col}_trend_strength_7']:
-        if col in df_with_trends.columns:
-            trend_sample_cols.append(col)
-    
-    available_sample_cols = [col for col in trend_sample_cols if col in df_with_trends.columns]
-    print(df_with_trends[available_sample_cols].head(10))
-    print()
-    
-    print("💡 Trend Feature Explanation:")
-    print("   - trend_N: Direction of change over N days (positive/negative)")
-    print("   - trend_strength_N: Magnitude of change relative to mean")
-    print("   - Helps models understand momentum and seasonality")
-    print()
-    
-    return df_with_trends
+    result = fe.create_trend_features(df, window_sizes=[7, 14])
+    _show_new_columns(df, result, "Trend features")
+    print("💡 trend_N = direction over N days; trend_strength = magnitude.\n")
+    return result
 
 
 def demonstrate_feature_scaling(df, fe):
-    """
-    ⚖️ Demonstrate feature scaling.
-    
-    Shows how numerical features are normalized for machine learning.
-    """
+    """STEP 8: feature scaling (standardize numeric features)."""
     print("⚖️  STEP 8: Feature Scaling")
     print("=" * 50)
-    
-    # Select numerical features for scaling (using actual column names from your schema)
-    numerical_cols = ['engagement_linkedin_no_video', 'num_followers_linkedin', 'day_of_week', 'month']
-    available_cols = [col for col in numerical_cols if col in df.columns]
-    
-    if not available_cols:
-        print("⚠️  Some expected columns not found. Available columns:")
-        print(f"   {list(df.columns[:10])}")
-        if len(df.columns) > 10:
-            print(f"   ... and {len(df.columns) - 10} more")
-        print("   Using available numeric columns instead.")
-        # Fallback to any numeric columns that exist
-        available_cols = df.select_dtypes(include=[np.number]).columns.tolist()
-        available_cols = [col for col in available_cols if col != 'date'][:4]  # Take first 4
-    
-    print(f"📊 Features to scale: {available_cols}")
-    print("Original feature values (first 5 rows):")
-    print(df[available_cols].head())
-    print()
-    
-    # Show statistics before scaling
-    print("📈 Feature statistics before scaling:")
-    print(df[available_cols].describe())
-    print()
-    
-    # Scale features
-    df_scaled = fe.scale_features(df, available_cols, scaler_type='standard')
-    
-    print("✨ Scaled features created:")
-    scaled_cols = [col for col in df_scaled.columns if col.endswith('_scaled')]
-    print(f"   Added {len(scaled_cols)} scaled features:")
-    
-    for col in scaled_cols:
-        print(f"   - {col}")
-    
-    print()
-    print("📊 Scaled feature values (first 5 rows):")
-    print(df_scaled[scaled_cols].head())
-    print()
-    
-    print("📈 Feature statistics after scaling:")
-    print(df_scaled[scaled_cols].describe())
-    print()
-    
-    print("💡 Scaling Explanation:")
-    print("   - Standard scaling: Mean=0, Standard deviation=1")
-    print("   - Helps models converge faster and perform better")
-    print("   - Prevents features with large values from dominating")
-    print()
-    
-    return df_scaled
+    numerical_cols = [
+        c
+        for c in ("engagement_linkedin_no_video", "num_followers_linkedin", "day_of_week", "month")
+        if c in df.columns
+    ]
+    if not numerical_cols:
+        numerical_cols = [c for c in df.select_dtypes(include=[np.number]).columns if c != "date"][:4]
+    print(f"📊 Scaling: {numerical_cols}")
+    result = fe.scale_features(df, numerical_cols, scaler_type="standard")
+    scaled_cols = [c for c in result.columns if c.endswith("_scaled")]
+    print(f"✨ Added {len(scaled_cols)} scaled features (mean≈0, std≈1)\n")
+    return result
+
+
+def _select_target_variable(df, feature_cols: List[str]) -> str:
+    """Interactively choose a numeric target column (default suggested)."""
+    default_target = "num_likes_linkedin_no_video"
+    if not (default_target in feature_cols and pd.api.types.is_numeric_dtype(df[default_target])):
+        numeric = [c for c in feature_cols if pd.api.types.is_numeric_dtype(df[c])]
+        default_target = numeric[0] if numeric else None
+
+    good_targets = [
+        c
+        for c in feature_cols
+        if pd.api.types.is_numeric_dtype(df[c])
+        and any(w in c.lower() for w in ("likes", "engagement", "followers", "comments", "shares"))
+    ]
+    if good_targets:
+        print("🎯 Good target options:", ", ".join(good_targets[:5]))
+
+    while True:
+        try:
+            prompt = (
+                f"Enter target variable (Enter for '{default_target}'): "
+                if default_target
+                else "Enter target variable name: "
+            )
+            choice = input(prompt).strip()
+            if not choice and default_target:
+                return default_target
+            if choice in feature_cols and pd.api.types.is_numeric_dtype(df[choice]):
+                return choice
+            print(f"❌ '{choice}' is not a valid numeric column. Try again.")
+        except KeyboardInterrupt:
+            print("\n👋 Using default target")
+            if default_target:
+                return default_target
+            numeric = [c for c in feature_cols if pd.api.types.is_numeric_dtype(df[c])]
+            return numeric[0] if numeric else feature_cols[0]
 
 
 def demonstrate_feature_importance(df, fe):
+    """STEP 9: target selection + data-driven feature ranking.
+
+    Delegates the ranking math to ``src.features.feature_ranking``; this
+    function only narrates the results.
     """
-    🎯 Demonstrate feature importance ranking and target variable selection.
-    
-    Shows how to choose what to predict and which features are most important.
-    """
-    print("🎯 STEP 9: Feature Importance & Target Variable Selection")
+    print("🎯 STEP 9: Feature Importance & Target Selection")
     print("=" * 60)
-    
-    # Get all feature columns (excluding date and any text columns that might not exist)
-    text_columns = [col for col in df.columns if 'text' in col.lower() or 'content' in col.lower()]
-    exclude_cols = ['date'] + text_columns
-    feature_cols = [col for col in df.columns if col not in exclude_cols]
-    
-    print(f"📊 Total features available: {len(feature_cols)}")
-    print("Available features for prediction:")
-    for i, col in enumerate(feature_cols[:15]):
-        print(f"   {i+1:2d}. {col}")
-    if len(feature_cols) > 15:
-        print(f"   ... and {len(feature_cols) - 15} more")
-    print()
-    
-    # Interactive target variable selection
-    print("🎯 CHOOSE YOUR TARGET VARIABLE (What do you want to predict?)")
-    print("=" * 50)
-    print("The target variable is what your machine learning model will try to predict.")
-    print("Choose a column that represents a business outcome you care about.")
-    print()
-    
-    # Default target variable
-    default_target = 'num_likes_linkedin_no_video'
-    
-    # Ensure default target exists and is numeric
-    if default_target in feature_cols and pd.api.types.is_numeric_dtype(df[default_target]):
-        print(f"💡 Default suggestion: {default_target}")
-        print("   This represents the number of likes on LinkedIn posts (no video)")
-        print("   It's a good target because it's directly measurable and actionable")
-        print()
-    else:
-        # Find a better default target
-        numeric_features = [col for col in feature_cols if pd.api.types.is_numeric_dtype(df[col])]
-        if numeric_features:
-            default_target = numeric_features[0]
-            print(f"💡 Default suggestion: {default_target}")
-            print("   This is a numeric column suitable for prediction")
-            print()
-        else:
-            default_target = None
-            print("⚠️  No suitable numeric columns found for target variable")
-            print()
-    
-    # Show some good target variable options (only numeric ones)
-    good_targets = [col for col in feature_cols 
-                   if pd.api.types.is_numeric_dtype(df[col]) and 
-                   any(word in col.lower() for word in ['likes', 'engagement', 'followers', 'comments', 'shares'])]
-    if good_targets:
-        print("🎯 Good target variable options:")
-        for i, col in enumerate(good_targets[:5]):
-            print(f"   {i+1}. {col}")
-        print()
-    
-    # Interactive selection
-    while True:
-        try:
-            if default_target and default_target in feature_cols:
-                choice = input(f"Enter target variable name (or press Enter for default '{default_target}'): ").strip()
-                if not choice:
-                    target_variable = default_target
-                    break
-            else:
-                choice = input("Enter target variable name: ").strip()
-            
-            if choice in feature_cols:
-                # Ensure the chosen target is numeric
-                if pd.api.types.is_numeric_dtype(df[choice]):
-                    target_variable = choice
-                    break
-                else:
-                    print(f"⚠️  '{choice}' is not numeric. Please choose a numeric column.")
-                    print("   Available numeric columns:")
-                    numeric_cols = [col for col in feature_cols if pd.api.types.is_numeric_dtype(df[col])]
-                    for i, col in enumerate(numeric_cols[:10]):
-                        print(f"   {i+1}. {col}")
-                    if len(numeric_cols) > 10:
-                        print(f"   ... and {len(numeric_cols) - 10} more")
-                    print()
-            else:
-                print(f"❌ '{choice}' not found in your data. Available options:")
-                print(f"   {list(feature_cols[:10])}")
-                if len(feature_cols) > 10:
-                    print(f"   ... and {len(feature_cols) - 10} more")
-                print()
-        except KeyboardInterrupt:
-            print("\n\n👋 Target selection cancelled, using default")
-            if default_target and default_target in feature_cols:
-                target_variable = default_target
-            else:
-                # Find any numeric column as fallback
-                numeric_cols = [col for col in feature_cols if pd.api.types.is_numeric_dtype(df[col])]
-                target_variable = numeric_cols[0] if numeric_cols else feature_cols[0]
-            break
-        except Exception as e:
-            print(f"❌ Error: {str(e)}")
-            print("   Please try again.")
-    
-    print(f"✅ Selected target variable: {target_variable}")
-    print()
-    
-    # Remove target variable from feature columns (we don't want to predict it using itself!)
+
+    text_columns = [c for c in df.columns if "text" in c.lower() or "content" in c.lower()]
+    feature_cols = [c for c in df.columns if c not in (["date"] + text_columns)]
+    print(f"📊 {len(feature_cols)} features available for prediction\n")
+
+    target_variable = _select_target_variable(df, feature_cols)
+    print(f"✅ Selected target: {target_variable}\n")
     if target_variable in feature_cols:
         feature_cols.remove(target_variable)
-        print(f"⚠️  Removed '{target_variable}' from features (can't predict using itself!)")
+
+    # Correlations with the target (reusable math from feature_ranking).
+    correlations = target_correlations(df, target_variable, feature_cols)
+    if not correlations.empty:
+        print("🔍 Top correlations with target:")
+        for i, (feature, corr) in enumerate(correlations.head(10).items(), 1):
+            strength = "Strong" if abs(corr) > 0.7 else "Moderate" if abs(corr) > 0.5 else "Weak"
+            print(f"   {i:2d}. {feature:<30} {corr:>6.3f} ({strength})")
         print()
-    
-    # Show correlation analysis with target variable
-    print("🔍 CORRELATION ANALYSIS WITH TARGET VARIABLE")
-    print("=" * 50)
-    print(f"Let's see which features correlate most with '{target_variable}':")
-    print()
-    
-    # Calculate correlations (only for numeric columns)
-    numeric_features = df[feature_cols].select_dtypes(include=[np.number])
-    if not numeric_features.empty:
-        try:
-            # Ensure target variable is numeric
-            if pd.api.types.is_numeric_dtype(df[target_variable]):
-                correlations = df[target_variable].corr(numeric_features)
-                correlations = correlations.sort_values(key=abs, ascending=False)
-                
-                print("📊 Feature correlations with target (absolute values):")
-                for i, (feature, corr) in enumerate(correlations.head(10).items(), 1):
-                    print(f"   {i:2d}. {feature}: {corr:.3f}")
-                print()
-                
-                # Show what correlations mean
-                print("💡 What correlations mean:")
-                print("   - Close to +1.0: Strong positive relationship (higher feature = higher target)")
-                print("   - Close to -1.0: Strong negative relationship (higher feature = lower target)")
-                print("   - Close to 0.0: No linear relationship")
-                print("   - |correlation| > 0.7: Strong relationship")
-                print("   - |correlation| > 0.5: Moderate relationship")
-                print("   - |correlation| > 0.3: Weak relationship")
-                print()
-            else:
-                print(f"⚠️  Target variable '{target_variable}' is not numeric, skipping correlation analysis")
-                print()
-        except Exception as e:
-            print(f"⚠️  Error calculating correlations: {str(e)}")
-            print("   This can happen with non-numeric data or missing values")
-            print("   Continuing with feature importance ranking...")
-            print()
-    else:
-        print("⚠️  No numeric features found for correlation analysis")
-        print()
-    
-    # Get feature importance ranking
-    print("🏆 FEATURE IMPORTANCE RANKING")
-    print("=" * 50)
-    print("Based on domain knowledge and correlation analysis:")
-    print()
-    
+
+    # Domain-knowledge ranking from the FeatureEngineer.
     try:
         ranked_features = fe.get_feature_importance_ranking(feature_cols)
-        
-        print("🏆 Feature importance ranking (top 20):")
-        for i, feature in enumerate(ranked_features[:20]):
-            print(f"   {i+1:2d}. {feature}")
-        print()
-    except Exception as e:
-        print(f"⚠️  Error getting feature importance ranking: {str(e)}")
-        print("   Using simple alphabetical ranking instead...")
-        print()
+    except Exception as exc:
+        print(f"⚠️  Domain ranking failed ({exc}); using alphabetical.\n")
         ranked_features = sorted(feature_cols)
-        
-        print("🏆 Simple feature ranking (alphabetical):")
-        for i, feature in enumerate(ranked_features[:20]):
-            print(f"   {i+1:2d}. {feature}")
-        print()
-    
-    # Add hard data analysis for feature ranking
-    print("📊 HARD DATA ANALYSIS FOR FEATURE RANKING")
-    print("=" * 60)
-    print("Let's analyze why features are ranked in this order using actual data:")
-    print()
-    
-    # 1. Variance analysis (higher variance = more information)
-    print("🔍 1. FEATURE VARIANCE ANALYSIS")
-    print("-" * 40)
-    print("Features with higher variance contain more information:")
-    print()
-    
-    variance_data = []
-    for col in feature_cols[:15]:  # Top 15 features
-        if pd.api.types.is_numeric_dtype(df[col]):
-            variance = df[col].var()
-            std = df[col].std()
-            mean = df[col].mean()
-            cv = std / mean if mean != 0 else 0  # Coefficient of variation
-            variance_data.append({
-                'feature': col,
-                'variance': variance,
-                'std': std,
-                'mean': mean,
-                'cv': cv
-            })
-    
-    # Sort by variance
-    variance_data.sort(key=lambda x: x['variance'], reverse=True)
-    
-    print("📊 Top 10 features by variance (most informative):")
+
+    # Data-driven analyses (all delegated to feature_ranking).
+    top = feature_cols[:15]
+    variance_data = variance_analysis(df, top)
+    missing_data = missing_value_analysis(df, top)
+    distribution_data = distribution_analysis(df, feature_cols[:10])
+    complexity_data = complexity_analysis(top)
+    scores = composite_scores(df, top)
+
+    print("🔍 Top features by variance (most informative):")
     for i, data in enumerate(variance_data[:10], 1):
         print(f"   {i:2d}. {data['feature']:<30} Var: {data['variance']:>10.2f} | CV: {data['cv']:>6.3f}")
     print()
-    
-    # 2. Missing value analysis
-    print("🔍 2. MISSING VALUE ANALYSIS")
-    print("-" * 40)
-    print("Features with fewer missing values are more reliable:")
-    print()
-    
-    missing_data = []
-    for col in feature_cols[:15]:
-        missing_count = df[col].isnull().sum()
-        missing_pct = (missing_count / len(df)) * 100
-        missing_data.append({
-            'feature': col,
-            'missing_count': missing_count,
-            'missing_pct': missing_pct
-        })
-    
-    # Sort by missing percentage (ascending)
-    missing_data.sort(key=lambda x: x['missing_pct'])
-    
-    print("📊 Top 10 features by data completeness:")
+
+    print("🔍 Top features by data completeness:")
     for i, data in enumerate(missing_data[:10], 1):
-        print(f"   {i:2d}. {data['feature']:<30} Missing: {data['missing_count']:>3d} ({data['missing_pct']:>5.1f}%)")
+        print(f"   {i:2d}. {data['feature']:<30} Missing: {data['missing_pct']:>5.1f}%")
     print()
-    
-    # 3. Correlation with target (if we have correlations)
-    if 'correlations' in locals() and not correlations.empty:
-        print("🔍 3. CORRELATION WITH TARGET ANALYSIS")
-        print("-" * 40)
-        print("Features with higher absolute correlation are more predictive:")
-        print()
-        
-        print("📊 Top 10 features by absolute correlation with target:")
-        for i, (feature, corr) in enumerate(correlations.head(10).items(), 1):
-            strength = "Strong" if abs(corr) > 0.7 else "Moderate" if abs(corr) > 0.5 else "Weak"
-            direction = "Positive" if corr > 0 else "Negative"
-            print(f"   {i:2d}. {feature:<30} {corr:>6.3f} ({strength} {direction})")
-        print()
-    
-    # 4. Feature distribution analysis
-    print("🔍 4. FEATURE DISTRIBUTION ANALYSIS")
-    print("-" * 40)
-    print("Features with better distributions are more suitable for ML:")
-    print()
-    
-    distribution_data = []
-    for col in feature_cols[:10]:  # Top 10 features
-        if pd.api.types.is_numeric_dtype(df[col]):
-            # Check for outliers using IQR method
-            Q1 = df[col].quantile(0.25)
-            Q3 = df[col].quantile(0.75)
-            IQR = Q3 - Q1
-            outlier_count = len(df[(df[col] < Q1 - 1.5*IQR) | (df[col] > Q3 + 1.5*IQR)])
-            outlier_pct = (outlier_count / len(df)) * 100
-            
-            # Check for zero variance
-            zero_var = df[col].var() == 0
-            
-            distribution_data.append({
-                'feature': col,
-                'outlier_count': outlier_count,
-                'outlier_pct': outlier_pct,
-                'zero_variance': zero_var,
-                'unique_values': df[col].nunique()
-            })
-    
-    print("📊 Feature distribution quality (lower outlier % = better):")
+
+    print("🔍 Distribution quality (lower outlier % = better):")
     for i, data in enumerate(distribution_data, 1):
-        quality = "Good" if data['outlier_pct'] < 5 else "Fair" if data['outlier_pct'] < 15 else "Poor"
-        print(f"   {i:2d}. {data['feature']:<30} Outliers: {data['outlier_pct']:>5.1f}% | Quality: {quality}")
+        quality = "Good" if data["outlier_pct"] < 5 else "Fair" if data["outlier_pct"] < 15 else "Poor"
+        print(f"   {i:2d}. {data['feature']:<30} Outliers: {data['outlier_pct']:>5.1f}% ({quality})")
     print()
-    
-    # 5. Feature engineering complexity
-    print("🔍 5. FEATURE ENGINEERING COMPLEXITY")
-    print("-" * 40)
-    print("Simple features are often more reliable than complex ones:")
-    print()
-    
-    complexity_data = []
-    for col in feature_cols[:15]:
-        # Determine complexity based on feature name patterns
-        complexity_score = 0
-        if any(word in col.lower() for word in ['lag', 'rolling', 'trend', 'ratio', 'rate']):
-            complexity_score += 2  # Engineered features
-        if any(word in col.lower() for word in ['sin', 'cos', 'cyclical']):
-            complexity_score += 1  # Cyclical encoding
-        if any(word in col.lower() for word in ['scaled', 'normalized']):
-            complexity_score += 1  # Scaled features
-        
-        complexity_level = "Simple" if complexity_score == 0 else "Medium" if complexity_score <= 2 else "Complex"
-        complexity_data.append({
-            'feature': col,
-            'complexity_score': complexity_score,
-            'complexity_level': complexity_level
-        })
-    
-    # Sort by complexity (ascending - simple first)
-    complexity_data.sort(key=lambda x: x['complexity_score'])
-    
-    print("📊 Feature complexity ranking (simpler = more reliable):")
+
+    print("🔍 Complexity (simpler = more reliable):")
     for i, data in enumerate(complexity_data[:10], 1):
-        print(f"   {i:2d}. {data['feature']:<30} Complexity: {data['complexity_level']:<8} (Score: {data['complexity_score']})")
+        print(f"   {i:2d}. {data['feature']:<30} {data['complexity_level']}")
     print()
-    
-    # 6. Final ranking explanation
-    print("🔍 6. FINAL RANKING EXPLANATION")
-    print("=" * 60)
-    print("Based on the hard data above, here's why features are ranked this way:")
-    print()
-    
-    print("🏆 TOP FEATURES (Why they're ranked first):")
-    if variance_data:
-        top_feature = variance_data[0]['feature']
-        print(f"   • {top_feature}: Highest variance ({variance_data[0]['variance']:.2f}) = most informative")
-    
-    if missing_data:
-        most_complete = missing_data[0]['feature']
-        print(f"   • {most_complete}: Most complete data ({missing_data[0]['missing_pct']:.1f}% missing)")
-    
-    if 'correlations' in locals() and not correlations.empty:
-        most_correlated = correlations.index[0]
-        corr_value = correlations.iloc[0]
-        print(f"   • {most_correlated}: Highest correlation with target ({corr_value:.3f})")
-    
-    if complexity_data:
-        simplest = complexity_data[0]['feature']
-        print(f"   • {simplest}: Simplest feature (Complexity score: {complexity_data[0]['complexity_score']})")
-    
-    print()
-    print("📊 RANKING FACTORS (in order of importance):")
-    print("   1. Data completeness (fewer missing values)")
-    print("   2. Correlation with target variable")
-    print("   3. Feature variance (information content)")
-    print("   4. Distribution quality (outlier percentage)")
-    print("   5. Feature complexity (simpler = better)")
-    print()
-    
-    # 7. Mathematical ranking calculation
-    print("🔍 7. MATHEMATICAL RANKING CALCULATION")
-    print("=" * 60)
-    print("Here's the exact mathematical formula used for ranking:")
-    print()
-    
-    # Calculate composite score for each feature
-    composite_scores = []
-    for col in feature_cols[:15]:
-        if pd.api.types.is_numeric_dtype(df[col]):
-            # Get all the metrics for this feature
-            var_data = next((x for x in variance_data if x['feature'] == col), None)
-            missing_data_item = next((x for x in missing_data if x['feature'] == col), None)
-            dist_data = next((x for x in distribution_data if x['feature'] == col), None)
-            comp_data = next((x for x in complexity_data if x['feature'] == col), None)
-            
-            if all([var_data, missing_data_item, dist_data, comp_data]):
-                # Normalize each metric to 0-1 scale
-                # Variance: higher is better, normalize by max variance
-                max_var = max(x['variance'] for x in variance_data)
-                norm_variance = var_data['variance'] / max_var if max_var > 0 else 0
-                
-                # Missing data: lower is better, invert and normalize
-                max_missing = max(x['missing_pct'] for x in missing_data)
-                norm_completeness = 1 - (missing_data_item['missing_pct'] / max_missing) if max_missing > 0 else 1
-                
-                # Distribution: lower outlier % is better, invert and normalize
-                max_outliers = max(x['outlier_pct'] for x in distribution_data)
-                norm_distribution = 1 - (dist_data['outlier_pct'] / max_outliers) if max_outliers > 0 else 1
-                
-                # Complexity: lower is better, invert and normalize
-                max_complexity = max(x['complexity_score'] for x in complexity_data)
-                norm_complexity = 1 - (comp_data['complexity_score'] / max_complexity) if max_complexity > 0 else 1
-                
-                # Calculate composite score (weighted average)
-                weights = [0.3, 0.25, 0.25, 0.2]  # Weights for each factor
-                composite_score = (
-                    norm_variance * weights[0] +
-                    norm_completeness * weights[1] +
-                    norm_distribution * weights[2] +
-                    norm_complexity * weights[3]
-                )
-                
-                composite_scores.append({
-                    'feature': col,
-                    'composite_score': composite_score,
-                    'norm_variance': norm_variance,
-                    'norm_completeness': norm_completeness,
-                    'norm_distribution': norm_distribution,
-                    'norm_complexity': norm_complexity,
-                    'raw_variance': var_data['variance'],
-                    'raw_missing_pct': missing_data_item['missing_pct'],
-                    'raw_outlier_pct': dist_data['outlier_pct'],
-                    'raw_complexity': comp_data['complexity_score']
-                })
-    
-    # Sort by composite score
-    composite_scores.sort(key=lambda x: x['composite_score'], reverse=True)
-    
-    print("📊 COMPOSITE SCORES (mathematical ranking):")
-    print("Formula: Score = 0.3×Variance + 0.25×Completeness + 0.25×Distribution + 0.2×Complexity")
-    print()
-    
-    print("🏆 Top 10 features by composite score:")
-    for i, score_data in enumerate(composite_scores[:10], 1):
-        print(f"   {i:2d}. {score_data['feature']:<30} Score: {score_data['composite_score']:>6.3f}")
-        print(f"       Variance: {score_data['norm_variance']:>6.3f} | Completeness: {score_data['norm_completeness']:>6.3f} | Distribution: {score_data['norm_distribution']:>6.3f} | Complexity: {score_data['norm_complexity']:>6.3f}")
-        print(f"       Raw: Var={score_data['raw_variance']:>8.2f}, Missing={score_data['raw_missing_pct']:>5.1f}%, Outliers={score_data['raw_outlier_pct']:>5.1f}%, Complexity={score_data['raw_complexity']}")
+
+    if scores:
+        print("🏆 Composite ranking")
+        print("   Score = 0.3×Variance + 0.25×Completeness + 0.25×Distribution + 0.2×Complexity")
+        for i, s in enumerate(scores[:10], 1):
+            print(f"   {i:2d}. {s['feature']:<30} Score: {s['composite_score']:>6.3f}")
         print()
-    
-    print("💡 MATHEMATICAL EXPLANATION:")
-    print("   • Each metric is normalized to 0-1 scale (0=worst, 1=best)")
-    print("   • Weights reflect relative importance of each factor")
-    print("   • Higher composite score = better feature for machine learning")
-    print("   • This is purely data-driven, no domain knowledge involved")
-    print()
-    
-    # 8. Compare mathematical vs domain knowledge ranking
-    print("🔍 8. MATHEMATICAL vs DOMAIN KNOWLEDGE COMPARISON")
-    print("=" * 60)
-    print("Let's see how the data-driven ranking differs from domain knowledge:")
-    print()
-    
-    if composite_scores and 'ranked_features' in locals():
-        print("📊 COMPARISON OF RANKING METHODS:")
+
+        # Compare data-driven vs domain-knowledge top 10.
+        math_top = [s["feature"] for s in scores[:10]]
+        domain_top = ranked_features[:10]
+        common = set(math_top) & set(domain_top)
+        print(f"📊 Data-driven vs domain ranking: {len(common)} features in both top 10s")
+        if common:
+            print("   Golden features (both methods):", ", ".join(sorted(common)))
         print()
-        
-        # Get top 10 from each method
-        math_top_10 = [score['feature'] for score in composite_scores[:10]]
-        domain_top_10 = ranked_features[:10]
-        
-        print("🏆 TOP 10 BY MATHEMATICAL SCORE (Data-driven):")
-        for i, feature in enumerate(math_top_10, 1):
-            print(f"   {i:2d}. {feature}")
-        print()
-        
-        print("🏆 TOP 10 BY DOMAIN KNOWLEDGE (Expert opinion):")
-        for i, feature in enumerate(domain_top_10, 1):
-            print(f"   {i:2d}. {feature}")
-        print()
-        
-        # Find common features in top 10
-        common_features = set(math_top_10) & set(domain_top_10)
-        math_only = set(math_top_10) - set(domain_top_10)
-        domain_only = set(domain_top_10) - set(math_top_10)
-        
-        print("📊 ANALYSIS OF DIFFERENCES:")
-        print(f"   • Features in BOTH top 10s: {len(common_features)}")
-        print(f"   • Only in mathematical top 10: {len(math_only)}")
-        print(f"   • Only in domain knowledge top 10: {len(domain_only)}")
-        print()
-        
-        if common_features:
-            print("✅ FEATURES AGREED UPON BY BOTH METHODS:")
-            for feature in sorted(common_features):
-                print(f"   • {feature}")
-            print()
-        
-        if math_only:
-            print("🔢 FEATURES RANKED HIGH BY DATA (but not domain knowledge):")
-            for feature in math_only:
-                # Find the mathematical score for this feature
-                score_data = next((s for s in composite_scores if s['feature'] == feature), None)
-                if score_data:
-                    print(f"   • {feature} (Score: {score_data['composite_score']:.3f})")
-            print()
-        
-        if domain_only:
-            print("🧠 FEATURES RANKED HIGH BY DOMAIN KNOWLEDGE (but not data):")
-            for feature in domain_only:
-                print(f"   • {feature}")
-            print()
-        
-        print("💡 KEY INSIGHTS:")
-        print("   • Mathematical ranking focuses on data quality and statistical properties")
-        print("   • Domain knowledge ranking considers business relevance and interpretability")
-        print("   • Features in both lists are your 'golden features' - use these first!")
-        print("   • Features only in mathematical ranking might be good but less interpretable")
-        print("   • Features only in domain ranking might be important but have data quality issues")
-        print()
-    
-    # Enhanced explanation
-    print("💡 FEATURE IMPORTANCE EXPLANATION")
-    print("=" * 50)
-    print("Feature importance helps you understand:")
-    print("   🎯 Which features matter most for predicting your target")
-    print("   🔍 Which features to focus on in your analysis")
-    print("   🚀 Which features to include in your machine learning model")
-    print("   💰 Which features might be worth collecting more data for")
-    print()
-    
-    print("📊 IMPORTANCE LEVELS:")
-    print("   🔴 HIGH IMPORTANCE: Strong influence on predictions")
-    print("     - These are your 'golden features'")
-    print("     - Focus your data collection efforts here")
-    print("     - These often represent core business drivers")
-    print()
-    print("   🟡 MEDIUM IMPORTANCE: Moderate influence on predictions")
-    print("     - Good supporting features")
-    print("     - Worth including in your model")
-    print("     - May provide incremental improvements")
-    print()
-    print("   🟢 LOW IMPORTANCE: Weak influence on predictions")
-    print("     - These might be noise or redundant")
-    print("     - Consider removing to simplify your model")
-    print("     - But don't discard without testing!")
-    print()
-    
-    print("🚀 NEXT STEPS FOR MACHINE LEARNING:")
-    print("   1. Use the top 10-15 features to start your model")
-    print("   2. Test different feature combinations")
-    print("   3. Monitor which features actually improve performance")
-    print("   4. Iterate and refine based on results")
-    print()
-    
+
     return ranked_features, target_variable
 
 
 def run_comprehensive_test():
-    """
-    🚀 Run the complete feature engineering test suite.
-    
-    This function demonstrates all capabilities of the FeatureEngineer class.
-    """
-    print("🚀 FEATURE ENGINEERING COMPREHENSIVE TEST")
+    """Run the full feature-engineering demo end to end."""
+    print("🚀 FEATURE ENGINEERING DEMO")
     print("=" * 60)
-    print("This test demonstrates all feature engineering capabilities")
-    print("Perfect for learning and testing your implementation")
-    print("=" * 60)
-    print()
-    
+
     try:
-        # Step 1: Choose data source and load data
         data_source = choose_data_source()
-        
-        if data_source == "sample":
-            df = create_sample_data()
-        else:  # real data
-            df = load_real_data_from_supabase()
-        
-        # Step 2: Show available features in the database
-        print("📊 AVAILABLE FEATURES IN YOUR DATABASE")
-        print("=" * 50)
-        print("These are the columns available for feature engineering:")
+        df = create_sample_data() if data_source == "sample" else load_real_data_from_supabase()
+
+        print("\n📊 Columns available for feature engineering:")
         for i, col in enumerate(df.columns, 1):
             print(f"   {i:2d}. {col}")
         print()
-        
-        # Step 3: Initialize feature engineer
-        print("🔧 Initializing FeatureEngineer...")
+
         fe = FeatureEngineer()
-        print("✅ FeatureEngineer initialized successfully!")
-        print()
-        
-        # Step 4: Apply all feature engineering methods
         df = demonstrate_temporal_features(df, fe)
         df = demonstrate_lag_features(df, fe)
         df = demonstrate_engagement_features(df, fe)
@@ -1074,80 +304,23 @@ def run_comprehensive_test():
         df = demonstrate_interaction_features(df, fe)
         df = demonstrate_trend_features(df, fe)
         df = demonstrate_feature_scaling(df, fe)
-        ranked_features, target_variable = demonstrate_feature_importance(df, fe)
-        
-        # Final summary
-        print("🎉 FEATURE ENGINEERING TEST COMPLETED SUCCESSFULLY!")
+        demonstrate_feature_importance(df, fe)
+
+        print("🎉 FEATURE ENGINEERING DEMO COMPLETED")
         print("=" * 60)
-        print(f"📊 Final dataset shape: {df.shape}")
-        print(f"✨ Total features created: {len(df.columns)}")
+        print(f"📊 Final shape: {df.shape} | total features: {len(df.columns)}")
         print(f"📅 Data covers: {df['date'].min()} to {df['date'].max()}")
-        print()
-        
-        print("🔍 Feature breakdown:")
-        # Define original columns based on what actually exists
-        original_cols = ['date', 'engagement_linkedin_no_video', 'num_followers_linkedin']
-        # Add any text columns if they exist
-        text_columns = [col for col in df.columns if 'text' in col.lower() or 'content' in col.lower()]
-        original_cols.extend(text_columns)
-        engineered_cols = [col for col in df.columns if col not in original_cols]
-        
-        print(f"   - Original columns: {len(original_cols)}")
-        print(f"   - Engineered features: {len(engineered_cols)}")
-        print()
-        
-        print("💡 What you've learned:")
-        print("   ✅ Temporal features (time patterns)")
-        print("   ✅ Lag features (historical trends)")
-        print("   ✅ Engagement features (normalized metrics)")
-        print("   ✅ Cross-platform features (unified view)")
-        print("   ✅ Content features (NLP analysis)")
-        print("   ✅ Interaction features (engagement ratios)")
-        print("   ✅ Trend features (momentum patterns)")
-        print("   ✅ Feature scaling (normalization)")
-        print("   ✅ Feature importance (prioritization)")
-        print()
-        
-        print("🚀 Next steps:")
-        print("   - Use these features to train machine learning models")
-        print("   - Experiment with different feature combinations")
-        print("   - Analyze which features improve model performance")
-        print("   - Customize features for your specific use case")
-        
         return True
-        
-    except Exception as e:
-        print(f"❌ Error during testing: {str(e)}")
+
+    except Exception as exc:
+        print(f"❌ Error during demo: {exc}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
 if __name__ == "__main__":
-    """
-    🎯 Main execution block.
-    
-    Run this script directly to test your FeatureEngineer implementation.
-    """
-    print("🧪 Feature Engineering Test Script")
-    print("=" * 40)
-    print("Testing and learning the FeatureEngineer class")
-    print("=" * 40)
-    print()
-    
+    print("🧪 Feature Engineering Demo\n")
     success = run_comprehensive_test()
-    
-    if success:
-        print("\n🎯 Test completed successfully!")
-        print("Your FeatureEngineer class is working correctly.")
-    else:
-        print("\n❌ Test failed. Check the error messages above.")
-        print("Make sure your FeatureEngineer class is properly implemented.")
-    
-    print("\n📚 Educational Notes:")
-    print("- This script shows how each feature is created step by step")
-    print("- Each method demonstrates a different aspect of feature engineering")
-    print("- You can choose between sample data and real Supabase data")
-    print("- Sample data is perfect for learning and testing")
-    print("- Real data tests your actual database connection")
-    print("- Modify the sample data to test different scenarios")
+    print("\n🎯 Demo completed." if success else "\n❌ Demo failed; see errors above.")

--- a/tests/demo_predictive_modeling.py
+++ b/tests/demo_predictive_modeling.py
@@ -1,87 +1,70 @@
-"""
-🧠 Predictive Modeling Test Script - Educational & Testing Purposes
+"""Predictive Modeling Demo - educational walkthrough.
 
-This script demonstrates how the predictive modeling system works by:
-1. Choosing between sample data or real Supabase data
-2. Applying feature engineering (silently)
-3. Creating and training multiple ML models
-4. Comparing model performance
-5. Making predictions for LinkedIn engagement
-6. Showing feature importance and practical results
-
-Run this script to:
-- Test your predictive modeling implementation
-- Learn how different models perform on LinkedIn data
-- See the impact of feature engineering on predictions
-- Debug any issues with model training
-- Test with your real social media data (if Supabase is connected)
+A thin narration layer over ``src.models.model_pipeline``: it loads data,
+applies feature engineering, then trains, evaluates, and compares the standard
+model zoo, printing a step-by-step commentary. The reusable logic lives in the
+pipeline module and is unit-tested in ``tests/test_model_pipeline.py``; this
+script only orchestrates and explains.
 
 Usage:
     python tests/demo_predictive_modeling.py
 
-Data Sources:
-- 📚 Sample Data: Creates realistic fake data (recommended for learning)
-- 🗄️ Real Data: Loads from your Supabase database (for production testing)
+Data sources:
+- Sample data: realistic fake data (recommended for learning)
+- Real data: loaded from Supabase (for production testing)
 """
 
-import sys
 import os
-import pandas as pd
-import numpy as np
+import sys
 import warnings
-warnings.filterwarnings('ignore')
 
-# Add src to path so we can import our modules
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+import numpy as np
+import pandas as pd
+
+warnings.filterwarnings("ignore")
+
+# Add src to path so we can import our modules.
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from features.feature_engineering import FeatureEngineer
-from models.prediction_models import (
-    RandomForestModel, XGBoostModel, LightGBMModel, CatBoostModel,
-    LinearRegressionModel, RidgeModel, SVRModel, MLPModel, EnsembleModel
+from models.model_pipeline import (
+    compare_model_performance,
+    create_all_models,
+    evaluate_all_models,
+    find_leakage_features,
+    prepare_modeling_data,
+    train_all_models,
 )
-from tests._sample_data import create_sample_data, load_real_data_from_supabase, choose_data_source
+from tests._sample_data import (
+    choose_data_source,
+    create_sample_data,
+    load_real_data_from_supabase,
+)
 
 
 def get_sample_size():
-    """
-    📏 Get desired sample size from user.
-    
-    Returns:
-        int: Number of rows to use for analysis
-    """
+    """Prompt for the desired sample size (rows). Defaults to 90."""
     print("📏 SAMPLE SIZE SELECTION")
     print("=" * 30)
     print("How many rows (most recent) would you like to analyze?")
-    print("💡 Recommendation:")
-    print("   - Small dataset (30-50): Fast, good for testing")
-    print("   - Medium dataset (60-100): Balanced performance and reliability")  
-    print("   - Large dataset (100+): Better model performance, slower training")
+    print("   - 30-50: fast, good for testing")
+    print("   - 60-100: balanced")
+    print("   - 100+: better performance, slower training")
     print()
-    
+
     while True:
         try:
             user_input = input("Enter number of rows (default 90): ").strip()
-            
-            if not user_input:  # User pressed enter without input
+            if not user_input:
                 return 90
-            
             sample_size = int(user_input)
-            
-            if sample_size < 10:
-                print("⚠️  Warning: Very small sample size may lead to poor model performance")
-                confirm = input("Continue anyway? (y/n): ").strip().lower()
-                if confirm != 'y':
+            if sample_size < 10 or sample_size > 500:
+                warn = "very small" if sample_size < 10 else "large"
+                print(f"⚠️  Warning: {warn} sample size.")
+                if input("Continue anyway? (y/n): ").strip().lower() != "y":
                     continue
-            elif sample_size > 500:
-                print("⚠️  Warning: Large sample size may slow down training significantly")
-                confirm = input("Continue anyway? (y/n): ").strip().lower()
-                if confirm != 'y':
-                    continue
-                    
-            print(f"✅ Using sample size: {sample_size} rows")
-            print()
+            print(f"✅ Using sample size: {sample_size} rows\n")
             return sample_size
-            
         except ValueError:
             print("❌ Please enter a valid number")
         except KeyboardInterrupt:
@@ -90,859 +73,240 @@ def get_sample_size():
 
 
 def show_data_quality_info(df, stage_name):
-    """
-    📊 Show data quality information at different stages.
-    
-    Args:
-        df: DataFrame to analyze
-        stage_name: Name of the current stage
-    """
+    """Print a compact data-quality snapshot for a stage."""
     print(f"📊 Data Quality Check - {stage_name}")
     print(f"   Shape: {df.shape}")
-    print(f"   Memory usage: {df.memory_usage(deep=True).sum() / 1024 / 1024:.2f} MB")
-    
-    # Check for missing values
-    missing_counts = df.isnull().sum()
-    missing_cols = missing_counts[missing_counts > 0]
-    
-    if len(missing_cols) > 0:
-        print(f"   ⚠️  Columns with missing values: {len(missing_cols)}")
-        print(f"   🔍 Top 5 columns with most missing values:")
-        for col, count in missing_cols.nlargest(5).items():
-            percentage = (count / len(df)) * 100
-            print(f"      {col}: {count} ({percentage:.1f}%)")
+    print(f"   Memory: {df.memory_usage(deep=True).sum() / 1024 / 1024:.2f} MB")
+
+    missing = df.isnull().sum()
+    missing = missing[missing > 0]
+    if len(missing) > 0:
+        print(f"   ⚠️  Columns with missing values: {len(missing)}")
+        for col, count in missing.nlargest(5).items():
+            print(f"      {col}: {count} ({count / len(df) * 100:.1f}%)")
     else:
         print("   ✅ No missing values found")
-    
-    # Check data types
-    dtypes = df.dtypes.value_counts()
-    print(f"   📝 Data types:")
-    for dtype, count in dtypes.items():
-        print(f"      {dtype}: {count} columns")
-    
     print()
 
 
 def apply_feature_engineering_silently(df, fe):
-    """
-    🔧 Apply feature engineering silently (no demonstration output).
-    
-    This prepares the data for predictive modeling.
-    """
-    print("🔧 Applying feature engineering (silently)...")
-    
+    """Run the feature-engineering pipeline with terse progress output."""
+    print("🔧 Applying feature engineering...")
+
+    steps = [
+        ("temporal", lambda d: fe.create_temporal_features(d, "date")),
+        (
+            "lag",
+            lambda d: fe.create_lag_features(
+                d,
+                [c for c in ("engagement_linkedin_no_video", "num_likes_linkedin_no_video") if c in d.columns],
+                lags=[1, 3, 7],
+            ),
+        ),
+        ("engagement", lambda d: fe.create_engagement_features(d, platforms=["linkedin", "instagram"])),
+        ("cross-platform", fe.create_cross_platform_features),
+        ("trend", lambda d: fe.create_trend_features(d, window_sizes=[7, 14])),
+    ]
+    for name, fn in steps:
+        try:
+            df = fn(df)
+            print(f"   ✅ {name} features")
+        except Exception as exc:
+            print(f"   ⚠️  {name}: {exc}")
+
     try:
-        # Create temporal features
-        df = fe.create_temporal_features(df, 'date')
-        print("   ✅ Temporal features created")
-    except Exception as e:
-        print(f"   ⚠️  Warning creating temporal features: {e}")
-    
-    try:
-        # Create lag features - only for columns that exist
-        target_cols = ['engagement_linkedin_no_video', 'num_likes_linkedin_no_video']
-        available_cols = [col for col in target_cols if col in df.columns]
-        if available_cols:
-            df = fe.create_lag_features(df, available_cols, lags=[1, 3, 7])
-            print(f"   ✅ Lag features created for {len(available_cols)} columns")
-        else:
-            print("   ⚠️  No suitable columns found for lag features")
-    except Exception as e:
-        print(f"   ⚠️  Warning creating lag features: {e}")
-    
-    try:
-        # Create engagement features
-        df = fe.create_engagement_features(df, platforms=['linkedin', 'instagram'])
-        print("   ✅ Engagement features created")
-    except Exception as e:
-        print(f"   ⚠️  Warning creating engagement features: {e}")
-    
-    try:
-        # Create cross-platform features
-        df = fe.create_cross_platform_features(df)
-        print("   ✅ Cross-platform features created")
-    except Exception as e:
-        print(f"   ⚠️  Warning creating cross-platform features: {e}")
-    
-    try:
-        # Create trend features - only for columns that exist
-        target_col = 'engagement_linkedin_no_video'
-        if target_col in df.columns:
-            df = fe.create_trend_features(df, window_sizes=[7, 14])
-            print("   ✅ Trend features created")
-        else:
-            print("   ⚠️  No engagement column found for trend features")
-    except Exception as e:
-        print(f"   ⚠️  Warning creating trend features: {e}")
-    
-    try:
-        # Scale features - only numeric columns
-        numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
-        exclude_cols = ['day_of_week', 'month', 'quarter', 'year', 'day_of_year', 'week_of_year']
-        numeric_cols = [col for col in numeric_cols if col not in exclude_cols]
+        exclude = {"day_of_week", "month", "quarter", "year", "day_of_year", "week_of_year"}
+        numeric_cols = [
+            c for c in df.select_dtypes(include=[np.number]).columns if c not in exclude
+        ]
         if numeric_cols:
-            df = fe.scale_features(df, numeric_cols, scaler_type='standard')
-            print(f"   ✅ Scaled {len(numeric_cols)} numeric features")
-        else:
-            print("   ⚠️  No numeric columns found for scaling")
-    except Exception as e:
-        print(f"   ⚠️  Warning scaling features: {e}")
-    
-    print(f"✅ Feature engineering completed. Dataset shape: {df.shape}")
-    
-    # Show data quality information after feature engineering
+            df = fe.scale_features(df, numeric_cols, scaler_type="standard")
+            print(f"   ✅ scaled {len(numeric_cols)} numeric features")
+    except Exception as exc:
+        print(f"   ⚠️  scaling: {exc}")
+
+    print(f"✅ Feature engineering done. Shape: {df.shape}\n")
     show_data_quality_info(df, "After Feature Engineering")
-    
-    print()
-    
     return df
 
 
-def diagnose_data_issues(df, target_col='num_likes_linkedin_no_video'):
-    """
-    🔍 Diagnose potential data issues that could cause prediction problems.
-    
-    Args:
-        df: DataFrame to analyze
-        target_col: Target column name
-    """
+def diagnose_data_issues(df, target_col="num_likes_linkedin_no_video"):
+    """Print target distribution, top correlations, and overfitting warnings."""
     print("🔍 DIAGNOSING POTENTIAL DATA ISSUES")
     print("=" * 50)
-    
+
     if target_col not in df.columns:
         print(f"❌ Target column '{target_col}' not found")
         return
-    
-    # Check target distribution
-    target_data = df[target_col]
-    print(f"🎯 Target Variable Analysis ({target_col}):")
-    print(f"   Mean: {target_data.mean():.2f}")
-    print(f"   Std:  {target_data.std():.2f}")
-    print(f"   Min:  {target_data.min():.2f}")
-    print(f"   Max:  {target_data.max():.2f}")
-    print(f"   Unique values: {target_data.nunique()}")
-    
-    # Check for constant target (major issue)
-    if target_data.nunique() <= 1:
-        print("   ❌ CRITICAL: Target has only 1 unique value!")
-        print("      This will cause models to predict the same value always.")
+
+    target = df[target_col]
+    print(f"🎯 Target '{target_col}': mean={target.mean():.2f} std={target.std():.2f} "
+          f"min={target.min():.2f} max={target.max():.2f} unique={target.nunique()}")
+
+    if target.nunique() <= 1:
+        print("   ❌ CRITICAL: target has only 1 unique value!")
         return
-    
-    # Check for very low variance
-    if target_data.std() < 0.01:
-        print("   ⚠️  WARNING: Target has very low variance")
-        print("      This may cause prediction instability.")
-    
-    # Check feature-target correlations
-    numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
-    numeric_cols = [col for col in numeric_cols if col != target_col]
-    
-    print(f"\n📊 Feature-Target Correlations (top 10):")
+    if target.std() < 0.01:
+        print("   ⚠️  WARNING: target has very low variance")
+
+    numeric_cols = [c for c in df.select_dtypes(include=[np.number]).columns if c != target_col]
     correlations = []
     for col in numeric_cols:
-        try:
-            corr = df[col].corr(target_data)
-            if not pd.isna(corr):
-                correlations.append((col, abs(corr)))
-        except:
-            continue
-    
+        corr = df[col].corr(target)
+        if not pd.isna(corr):
+            correlations.append((col, abs(corr)))
     correlations.sort(key=lambda x: x[1], reverse=True)
-    for i, (col, corr) in enumerate(correlations[:10]):
-        print(f"   {i+1:2d}. {col[:40]:40} {corr:.4f}")
-    
-    # Check for perfect correlations (data leakage)
-    perfect_corrs = [col for col, corr in correlations if corr > 0.99]
-    if perfect_corrs:
-        print(f"\n   ⚠️  WARNING: Perfect correlations detected (possible data leakage):")
-        for col in perfect_corrs:
+
+    print("\n📊 Feature-Target Correlations (top 10):")
+    for i, (col, corr) in enumerate(correlations[:10], 1):
+        print(f"   {i:2d}. {col[:40]:40} {corr:.4f}")
+
+    leakage = [col for col, corr in correlations if corr > 0.99]
+    if leakage:
+        print("\n   ⚠️  Perfect correlations (possible leakage):")
+        for col in leakage:
             print(f"      {col}")
-    
-    # Check dataset size
-    print(f"\n📏 Dataset Size Analysis:")
-    print(f"   Rows: {len(df)}")
-    print(f"   Features: {len(numeric_cols)}")
-    print(f"   Features/Rows ratio: {len(numeric_cols)/len(df):.2f}")
-    
+
+    ratio = len(numeric_cols) / len(df) if len(df) else 0
+    print(f"\n📏 Rows: {len(df)} | Features: {len(numeric_cols)} | ratio: {ratio:.2f}")
     if len(numeric_cols) >= len(df):
-        print("   ❌ CRITICAL: More features than samples!")
-        print("      This will cause severe overfitting.")
-    elif len(numeric_cols) / len(df) > 0.1:
-        print("   ⚠️  WARNING: High feature-to-sample ratio")
-        print("      This may cause overfitting.")
-    
+        print("   ❌ CRITICAL: more features than samples (severe overfitting risk)")
+    elif ratio > 0.1:
+        print("   ⚠️  WARNING: high feature-to-sample ratio")
     print()
-
-
-def remove_data_leakage_features(feature_cols, target_col):
-    """
-    🚫 Remove features that cause data leakage.
-    
-    Data leakage occurs when features are derived from the target variable,
-    leading to unrealistically perfect predictions.
-    
-    Args:
-        feature_cols: List of feature column names
-        target_col: Target column name
-        
-    Returns:
-        List of cleaned feature columns
-    """
-    print("🚫 REMOVING DATA LEAKAGE FEATURES")
-    print("=" * 40)
-    
-    # Find target-derived features
-    target_base = target_col.replace('_scaled', '')  # Handle scaled versions
-    leakage_features = []
-    
-    for col in feature_cols:
-        # Check if feature contains the target name (but isn't the target itself)
-        if target_base in col and col != target_col:
-            # Common leakage patterns
-            leakage_patterns = ['_rolling_', '_lag_', '_scaled', '_rate', '_trend', '_diff']
-            if any(pattern in col for pattern in leakage_patterns):
-                leakage_features.append(col)
-    
-    if leakage_features:
-        print(f"🔍 Found {len(leakage_features)} potential data leakage features:")
-        for i, col in enumerate(leakage_features[:10]):  # Show first 10
-            print(f"   {i+1:2d}. {col}")
-        if len(leakage_features) > 10:
-            print(f"   ... and {len(leakage_features) - 10} more")
-        
-        # Remove leakage features
-        clean_features = [col for col in feature_cols if col not in leakage_features]
-        print(f"✅ Removed {len(leakage_features)} leakage features")
-        print(f"📊 Features before: {len(feature_cols)} -> after: {len(clean_features)}")
-        print()
-        
-        return clean_features
-    else:
-        print("✅ No data leakage features detected")
-        print()
-        return feature_cols
-
-
-def prepare_modeling_data(df, target_col='num_likes_linkedin_no_video'):
-    """
-    📊 Prepare data for modeling by separating features and target.
-    
-    Args:
-        df: DataFrame with features and target
-        target_col: Name of the target column
-        
-    Returns:
-        Tuple of (features DataFrame, target Series)
-    """
-    print(f"📊 Preparing data for modeling with target: {target_col}")
-    
-    # Ensure target column exists
-    if target_col not in df.columns:
-        print(f"⚠️  Target column '{target_col}' not found in data")
-        
-        # Look for alternative target columns
-        possible_targets = []
-        
-        # First priority: engagement columns
-        engagement_cols = [col for col in df.columns if 'engagement' in col.lower()]
-        possible_targets.extend(engagement_cols)
-        
-        # Second priority: like columns
-        like_cols = [col for col in df.columns if 'like' in col.lower()]
-        possible_targets.extend(like_cols)
-        
-        # Third priority: comment columns
-        comment_cols = [col for col in df.columns if 'comment' in col.lower()]
-        possible_targets.extend(comment_cols)
-        
-        # Fourth priority: any numeric columns that might be suitable
-        numeric_cols = df.select_dtypes(include=[np.number]).columns.tolist()
-        # Filter out date-related columns
-        numeric_cols = [col for col in numeric_cols if not any(x in col.lower() for x in ['date', 'day', 'month', 'year', 'week', 'quarter'])]
-        possible_targets.extend(numeric_cols)
-        
-        if possible_targets:
-            # Remove duplicates while preserving order
-            seen = set()
-            unique_targets = []
-            for col in possible_targets:
-                if col not in seen:
-                    seen.add(col)
-                    unique_targets.append(col)
-            
-            # Select the first available target
-            target_col = unique_targets[0]
-            print(f"✅ Using alternative target column: {target_col}")
-        else:
-            raise ValueError(f"No suitable target column found in data. Available columns: {list(df.columns)}")
-    
-    # Get feature columns (exclude date and target)
-    feature_cols = [col for col in df.columns if col not in ['date', target_col]]
-    
-    # Remove data leakage features
-    feature_cols = remove_data_leakage_features(feature_cols, target_col)
-    
-    # Select features and target
-    X = df[feature_cols].copy()
-    y = df[target_col].copy()
-    
-    # Handle missing values more intelligently
-    print(f"📊 Original data shape: {X.shape}")
-    print(f"🔍 Missing values in features: {X.isnull().sum().sum()}")
-    print(f"🔍 Missing values in target: {y.isnull().sum()}")
-    
-    # Fill missing values in features with appropriate strategies
-    for col in X.columns:
-        if X[col].dtype in ['int64', 'float64']:
-            # For numeric columns, fill with median (more robust than mean)
-            median_val = X[col].median()
-            if pd.isna(median_val):
-                median_val = 0  # Fallback to 0 if median is also NaN
-            X[col] = X[col].fillna(median_val)
-        else:
-            # For categorical/text columns, fill with mode or empty string
-            mode_val = X[col].mode()
-            if len(mode_val) > 0 and not pd.isna(mode_val.iloc[0]):
-                X[col] = X[col].fillna(mode_val.iloc[0])
-            else:
-                X[col] = X[col].fillna('')
-    
-    # Fill missing values in target with median
-    y_median = y.median()
-    if pd.isna(y_median):
-        y_median = 0
-    y = y.fillna(y_median)
-    
-    print(f"📊 After filling missing values - Features shape: {X.shape}")
-    print(f"📊 After filling missing values - Target shape: {y.shape}")
-    print(f"🎯 Target variable: {target_col}")
-    print(f"🔧 Features: {len(feature_cols)}")
-    print()
-    
-    return X, y, feature_cols
-
-
-def create_all_models(target_col, feature_cols):
-    """
-    🏗️ Create all available prediction models.
-    
-    Args:
-        target_col: Target column name
-        feature_cols: List of feature columns
-        
-    Returns:
-        Dictionary of initialized models
-    """
-    print("🏗️  Creating all prediction models...")
-    
-    models = {}
-    
-    # Tree-based models
-    models['random_forest'] = RandomForestModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        n_estimators=100,
-        max_depth=10,
-        random_state=42
-    )
-    
-    models['xgboost'] = XGBoostModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        n_estimators=100,
-        max_depth=6,
-        learning_rate=0.1,
-        random_state=42
-    )
-    
-    models['lightgbm'] = LightGBMModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        n_estimators=100,
-        max_depth=6,
-        learning_rate=0.1,
-        random_state=42
-    )
-    
-    models['catboost'] = CatBoostModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        iterations=100,
-        depth=6,
-        learning_rate=0.1,
-        random_state=42
-    )
-    
-    # Linear models
-    models['linear_regression'] = LinearRegressionModel(
-        target_column=target_col,
-        feature_columns=feature_cols
-    )
-    
-    models['ridge'] = RidgeModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        alpha=1.0,
-        random_state=42
-    )
-    
-    # Neural network
-    models['mlp'] = MLPModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        hidden_layer_sizes=(100, 50),
-        max_iter=1000,
-        random_state=42
-    )
-    
-    # Support Vector Regression
-    models['svr'] = SVRModel(
-        target_column=target_col,
-        feature_columns=feature_cols,
-        kernel='rbf',
-        C=1.0,
-        epsilon=0.1
-    )
-    
-    # Ensemble model
-    ensemble = EnsembleModel(
-        target_column=target_col,
-        feature_columns=feature_cols
-    )
-    
-    # Add top models to ensemble
-    top_models = ['random_forest', 'xgboost', 'lightgbm']
-    for model_name in top_models:
-        if model_name in models:
-            ensemble.add_model(models[model_name], weight=1.0)
-    
-    models['ensemble'] = ensemble
-    
-    print(f"✅ Created {len(models)} models: {list(models.keys())}")
-    print()
-    
-    return models
-
-
-def train_all_models(models, X, y):
-    """
-    🚀 Train all models on the data.
-    
-    Args:
-        models: Dictionary of models
-        X: Feature DataFrame
-        y: Target Series
-        
-    Returns:
-        Dictionary of trained models
-    """
-    print("🚀 Training all models...")
-    
-    trained_models = {}
-    failed_models = []
-    
-    for name, model in models.items():
-        try:
-            print(f"🔄 Training {name}...")
-            model.fit(X, y)
-            trained_models[name] = model
-            print(f"✅ {name} trained successfully")
-        except Exception as e:
-            print(f"❌ Error training {name}: {e}")
-            failed_models.append(name)
-            continue
-    
-    print(f"✅ Successfully trained {len(trained_models)} models")
-    if failed_models:
-        print(f"❌ Failed to train {len(failed_models)} models: {failed_models}")
-    print()
-    
-    return trained_models
-
-
-def evaluate_all_models(models, X, y):
-    """
-    📊 Evaluate all trained models.
-    
-    Args:
-        models: Dictionary of trained models
-        X: Feature DataFrame
-        y: Target Series
-        
-    Returns:
-        Dictionary of evaluation metrics for each model
-    """
-    print("📊 Evaluating all models...")
-    
-    evaluation_results = {}
-    
-    if not models:
-        print("⚠️  No trained models available for evaluation")
-        return evaluation_results
-    
-    for name, model in models.items():
-        try:
-            print(f"📊 Evaluating {name}...")
-            metrics = model.evaluate(X, y)
-            evaluation_results[name] = metrics
-            
-            # Log key metrics
-            if 'r2' in metrics:
-                print(f"   {name} R²: {metrics['r2']:.4f}")
-            if 'mae' in metrics:
-                print(f"   {name} MAE: {metrics['mae']:.2f}")
-                
-        except Exception as e:
-            print(f"❌ Error evaluating {name}: {e}")
-            continue
-    
-    print()
-    return evaluation_results
-
-
-def compare_model_performance(evaluation_results):
-    """
-    🔍 Compare model performance and create ranking.
-    
-    Args:
-        evaluation_results: Dictionary of evaluation metrics
-        
-    Returns:
-        DataFrame with model comparison
-    """
-    print("🔍 Comparing model performance...")
-    
-    if not evaluation_results:
-        print("⚠️  No model evaluation results available for comparison")
-        return pd.DataFrame()
-    
-    # Create comparison DataFrame
-    comparison_data = []
-    for model_name, metrics in evaluation_results.items():
-        row = {'Model': model_name}
-        row.update(metrics)
-        comparison_data.append(row)
-    
-    if comparison_data:
-        comparison_df = pd.DataFrame(comparison_data)
-        
-        # Sort by R² score if available, otherwise by MAE
-        if 'r2' in comparison_df.columns:
-            comparison_df = comparison_df.sort_values('r2', ascending=False)
-            print("🏆 Model Performance Ranking (by R² score):")
-        elif 'mae' in comparison_df.columns:
-            comparison_df = comparison_df.sort_values('mae', ascending=True)
-            print("🏆 Model Performance Ranking (by MAE score):")
-        else:
-            print("🏆 Model Performance Ranking:")
-        
-        for i, row in comparison_df.iterrows():
-            model_name = row['Model']
-            if 'r2' in row:
-                print(f"   {i+1}. {model_name}: R² = {row['r2']:.4f}")
-            elif 'mae' in row:
-                print(f"   {i+1}. {model_name}: MAE = {row['mae']:.2f}")
-            else:
-                print(f"   {i+1}. {model_name}")
-        
-        print()
-        return comparison_df
-    else:
-        print("⚠️  No valid model comparison data available")
-        return pd.DataFrame()
 
 
 def demonstrate_predictions(models, X, feature_cols, y=None):
-    """
-    🎯 Demonstrate predictions for different scenarios.
-    
-    Args:
-        models: Dictionary of trained models
-        X: Feature DataFrame
-        feature_cols: List of feature columns
-        y: Target Series (optional, for showing actual vs predicted)
-    """
+    """Run sample predictions and flag identical/divergent outputs."""
     print("🎯 DEMONSTRATING PREDICTIONS")
     print("=" * 50)
-    
-    if not models:
-        print("⚠️  No trained models available for predictions")
+
+    if not models or len(X) == 0:
+        print("⚠️  No models or no data available for predictions")
         return
-    
-    # Get sample data for predictions - use different rows for variety
-    if len(X) > 0:
-        # Select diverse samples from different parts of the dataset
-        sample_indices = []
-        if len(X) >= 3:
-            sample_indices = [0, len(X)//2, len(X)-1]  # First, middle, last
-        else:
-            sample_indices = list(range(len(X)))
-        
-        sample_data = X.iloc[sample_indices]
-        print(f"📊 Sample predictions for {len(sample_data)} data points:")
-        
-        for i, (idx, row) in enumerate(sample_data.iterrows()):
-            print(f"\n📊 Sample {i+1} (Row {idx}):")
-            
-            # Show key feature values for this sample
-            print("   🔍 Key Feature Values:")
-            key_features = [col for col in X.columns if any(key in col.lower() for key in 
-                          ['num_likes_linkedin_no_video', 'engagement_linkedin_no_video', 'day_of_week', 'is_weekend'])][:5]
-            for feat in key_features:
-                if feat in X.columns:
-                    print(f"      {feat}: {row[feat]:.2f}")
-            
-            # Show actual target value if available
-            if y is not None:
-                actual_value = y.iloc[idx] if hasattr(y, 'iloc') else y[idx]
-                print(f"   🎯 Actual Target Value: {actual_value:.2f}")
-            
-            print("   🤖 Model Predictions:")
-            for name, model in models.items():
-                try:
-                    prediction = model.predict(row.to_frame().T)
-                    if hasattr(prediction, '__len__') and len(prediction) > 0:
-                        pred_value = prediction[0]
-                    else:
-                        pred_value = prediction
-                    
-                    # Show difference from actual if available
-                    if y is not None:
-                        actual_value = y.iloc[idx] if hasattr(y, 'iloc') else y[idx]
-                        diff = pred_value - actual_value
-                        print(f"      {name}: {pred_value:.2f} (diff: {diff:+.2f})")
-                    else:
-                        print(f"      {name}: {pred_value:.2f}")
-                except Exception as e:
-                    print(f"      {name}: Error - {e}")
-        
-        # Check if all predictions are identical (potential issue)
-        print(f"\n🔍 PREDICTION ANALYSIS:")
-        if len(models) > 1:
-            all_predictions = {}
-            for name, model in models.items():
-                try:
-                    pred = model.predict(sample_data)
-                    all_predictions[name] = pred
-                except:
-                    continue
-            
-            # Check for identical predictions across samples
-            for model_name, predictions in all_predictions.items():
-                if len(set(predictions.round(2))) == 1:
-                    print(f"   ⚠️  WARNING: {model_name} gives identical predictions for all samples!")
-                    print(f"      This suggests overfitting or data leakage issues.")
-                
-            # Check for huge differences between models
-            if len(all_predictions) > 1:
-                pred_ranges = {}
-                for i in range(len(sample_data)):
-                    sample_preds = [preds[i] for preds in all_predictions.values()]
-                    pred_range = max(sample_preds) - min(sample_preds)
-                    pred_ranges[f"Sample {i+1}"] = pred_range
-                
-                max_range = max(pred_ranges.values())
-                if max_range > 50:  # Arbitrary threshold
-                    print(f"   ⚠️  WARNING: Large prediction differences detected!")
-                    print(f"      Maximum range: {max_range:.2f}")
-                    print(f"      This suggests model instability or data issues.")
-    else:
-        print("⚠️  No data available for predictions")
-    
-    print("\n💡 Prediction Insights:")
-    print("   • Different models may give different predictions")
-    print("   • Identical predictions across samples indicate potential issues")
-    print("   • Large prediction ranges suggest model instability")
-    print("   • Ensemble models often provide more stable results")
-    print("   • Use the best performing model for production")
-    print()
+
+    sample_indices = [0, len(X) // 2, len(X) - 1] if len(X) >= 3 else list(range(len(X)))
+    sample_data = X.iloc[sample_indices]
+    print(f"📊 Sample predictions for {len(sample_data)} data points:")
+
+    for i, (idx, row) in enumerate(sample_data.iterrows()):
+        print(f"\n📊 Sample {i + 1} (Row {idx}):")
+        if y is not None:
+            actual = y.iloc[idx] if hasattr(y, "iloc") else y[idx]
+            print(f"   🎯 Actual: {actual:.2f}")
+        for name, model in models.items():
+            try:
+                prediction = model.predict(row.to_frame().T)
+                pred_value = prediction[0] if hasattr(prediction, "__len__") else prediction
+                if y is not None:
+                    actual = y.iloc[idx] if hasattr(y, "iloc") else y[idx]
+                    print(f"      {name}: {pred_value:.2f} (diff: {pred_value - actual:+.2f})")
+                else:
+                    print(f"      {name}: {pred_value:.2f}")
+            except Exception as exc:
+                print(f"      {name}: Error - {exc}")
+
+    print("\n💡 Identical predictions across samples suggest overfitting / leakage;")
+    print("   large divergence between models suggests instability.\n")
 
 
 def show_feature_importance(models, feature_cols):
-    """
-    🎯 Show feature importance analysis.
-    
-    Args:
-        models: Dictionary of trained models
-        feature_cols: List of feature columns
-    """
+    """Print top-10 feature importances from the first tree model that has them."""
     print("🎯 FEATURE IMPORTANCE ANALYSIS")
     print("=" * 50)
-    
-    if not models:
-        print("⚠️  No trained models available for feature importance analysis")
-        return
-    
-    # Try to get feature importance from tree-based models
-    tree_models = ['random_forest', 'xgboost', 'lightgbm', 'catboost']
-    
-    for model_name in tree_models:
-        if model_name in models:
-            try:
-                model = models[model_name]
-                if hasattr(model, 'get_feature_importance'):
-                    importance = model.get_feature_importance()
-                    if importance is not None and len(importance) > 0:
-                        print(f"🔍 {model_name.upper()} Feature Importance:")
-                        
-                        # Create importance DataFrame from dictionary
-                        importance_df = pd.DataFrame([
-                            {'Feature': feature, 'Importance': score}
-                            for feature, score in importance.items()
-                        ]).sort_values('Importance', ascending=False)
-                        
-                        # Show top 10 features
-                        top_features = importance_df.head(10)
-                        for i, (_, row) in enumerate(top_features.iterrows()):
-                            print(f"   {i+1:2d}. {row['Feature']:30} {row['Importance']:8.4f}")
-                        
-                        print()
-                        return  # Found feature importance, exit
-                        
-            except Exception as e:
-                print(f"⚠️  Error getting feature importance from {model_name}: {e}")
-                continue
-    
-    print("⚠️  No feature importance available from any model")
-    print("   • Tree-based models (Random Forest, XGBoost, LightGBM, CatBoost) provide feature importance")
-    print("   • Linear models can provide coefficient importance")
-    print("   • Consider using a tree-based model for feature importance analysis")
-    print()
+
+    for model_name in ("random_forest", "xgboost", "lightgbm", "catboost"):
+        model = models.get(model_name)
+        if model is None or not hasattr(model, "get_feature_importance"):
+            continue
+        try:
+            importance = model.get_feature_importance()
+            if importance:
+                print(f"🔍 {model_name.upper()} Feature Importance (top 10):")
+                ranked = sorted(importance.items(), key=lambda kv: kv[1], reverse=True)
+                for i, (feature, score) in enumerate(ranked[:10], 1):
+                    print(f"   {i:2d}. {feature:30} {score:8.4f}")
+                print()
+                return
+        except Exception as exc:
+            print(f"⚠️  {model_name}: {exc}")
+
+    print("⚠️  No feature importance available (use a tree-based model)\n")
 
 
 def run_comprehensive_test():
-    """
-    🚀 Run the complete predictive modeling test suite.
-    
-    This function demonstrates all capabilities of the predictive modeling system.
-    """
-    print("🚀 PREDICTIVE MODELING COMPREHENSIVE TEST")
+    """Run the full predictive-modeling demo end to end."""
+    print("🚀 PREDICTIVE MODELING DEMO")
     print("=" * 60)
-    print("This test demonstrates predictive modeling capabilities")
-    print("Perfect for learning and testing your implementation")
-    print("=" * 60)
-    print()
-    
+
     try:
-        # Step 1: Choose data source and load data
         data_source = choose_data_source()
-        
-        # Step 1.5: Get sample size if using real data
-        if data_source == "real":
-            sample_size = get_sample_size()
-        else:
-            sample_size = 90  # Default for sample data
-        
-        if data_source == "sample":
-            df = create_sample_data(sample_size)
-        else:  # real data
-            df = load_real_data_from_supabase(sample_size)
-        
-        # Step 2: Show available features in the database
-        print("📊 AVAILABLE FEATURES IN YOUR DATABASE")
-        print("=" * 50)
-        print("These are the columns available for modeling:")
+        sample_size = get_sample_size() if data_source == "real" else 90
+        df = (
+            create_sample_data(sample_size)
+            if data_source == "sample"
+            else load_real_data_from_supabase(sample_size)
+        )
+
+        print("\n📊 Columns available for modeling:")
         for i, col in enumerate(df.columns, 1):
             print(f"   {i:2d}. {col}")
         print()
-        
-        # Show initial data quality
         show_data_quality_info(df, "Initial Data Load")
-        
-        # Step 3: Initialize feature engineer
-        print("🔧 Initializing FeatureEngineer...")
+
         fe = FeatureEngineer()
-        print("✅ FeatureEngineer initialized successfully!")
-        print()
-        
-        # Step 4: Apply feature engineering silently
         df_with_features = apply_feature_engineering_silently(df, fe)
-        
-        # Step 4.5: Diagnose potential data issues
-        diagnose_data_issues(df_with_features, target_col='num_likes_linkedin_no_video')
-        
-        # Step 5: Prepare data for modeling
-        X, y, feature_cols = prepare_modeling_data(df_with_features)
-        
-        # Show data quality after preparation
+        diagnose_data_issues(df_with_features, target_col="num_likes_linkedin_no_video")
+
+        # Reusable pipeline logic (leakage removal + imputation + target resolution).
+        target_guess = "num_likes_linkedin_no_video"
+        raw_feature_cols = [c for c in df_with_features.columns if c not in ("date", target_guess)]
+        leakage = find_leakage_features(raw_feature_cols, target_guess)
+        if leakage:
+            print(f"🚫 Removing {len(leakage)} data-leakage features "
+                  f"(e.g. {', '.join(leakage[:3])})\n")
+
+        X, y, feature_cols = prepare_modeling_data(df_with_features, target_col=target_guess)
+        print(f"📊 Prepared X={X.shape}, target='{y.name}', features={len(feature_cols)}\n")
         show_data_quality_info(X, "After Data Preparation (Features)")
-        show_data_quality_info(pd.DataFrame(y), "After Data Preparation (Target)")
-        
-        # Step 6: Create all models
+
         models = create_all_models(y.name, feature_cols)
-        
-        # Step 7: Train all models
-        trained_models = train_all_models(models, X, y)
-        
-        # Step 8: Evaluate all models
+        print(f"🏗️  Created {len(models)} models: {list(models.keys())}\n")
+
+        trained_models, failed = train_all_models(models, X, y)
+        print(f"✅ Trained {len(trained_models)} models" +
+              (f"; failed: {failed}" if failed else "") + "\n")
+
         evaluation_results = evaluate_all_models(trained_models, X, y)
-        
-        # Step 9: Compare model performance
         comparison_df = compare_model_performance(evaluation_results)
-        
-        # Step 10: Demonstrate predictions
+        if not comparison_df.empty:
+            print("🏆 Model Performance Ranking:")
+            for i, row in comparison_df.iterrows():
+                if "r2" in row:
+                    print(f"   {i + 1}. {row['Model']}: R² = {row['r2']:.4f}")
+                elif "mae" in row:
+                    print(f"   {i + 1}. {row['Model']}: MAE = {row['mae']:.2f}")
+            print()
+
         demonstrate_predictions(trained_models, X, feature_cols, y)
-        
-        # Step 11: Show feature importance
         show_feature_importance(trained_models, feature_cols)
-        
-        # Final summary
-        print("🎉 PREDICTIVE MODELING TEST COMPLETED SUCCESSFULLY!")
+
+        print("🎉 PREDICTIVE MODELING DEMO COMPLETED")
         print("=" * 60)
-        print(f"📊 Final dataset shape: {df_with_features.shape}")
-        print(f"✨ Total features created: {len(feature_cols)}")
+        print(f"📊 Final shape: {df_with_features.shape} | features: {len(feature_cols)} "
+              f"| models: {len(trained_models)}")
         print(f"📅 Data covers: {df['date'].min()} to {df['date'].max()}")
-        print(f"🤖 Models tested: {len(trained_models)}")
-        print()
-        
-        print("🔍 What you've learned:")
-        print("   ✅ How to prepare data for predictive modeling")
-        print("   ✅ How to create and train multiple ML models")
-        print("   ✅ How to compare model performance")
-        print("   ✅ How to make predictions with different models")
-        print("   ✅ How to interpret feature importance")
-        print()
-        
-        print("🚀 Next steps:")
-        print("   - Use the best performing model for your predictions")
-        print("   - Experiment with different feature combinations")
-        print("   - Collect more data to improve model performance")
-        print("   - Deploy your model for real-time predictions")
-        
         return True
-        
-    except Exception as e:
-        print(f"❌ Error during testing: {str(e)}")
+
+    except Exception as exc:
+        print(f"❌ Error during demo: {exc}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
 if __name__ == "__main__":
-    """
-    🎯 Main execution block.
-    
-    Run this script directly to test your predictive modeling implementation.
-    """
-    print("🧠 Predictive Modeling Test Script")
-    print("=" * 40)
-    print("Testing and learning the predictive modeling system")
-    print("=" * 40)
-    print()
-    
+    print("🧠 Predictive Modeling Demo\n")
     success = run_comprehensive_test()
-    
-    if success:
-        print("\n🎯 Test completed successfully!")
-        print("Your predictive modeling system is working correctly.")
-    else:
-        print("\n❌ Test failed. Check the error messages above.")
-        print("Make sure your models and feature engineering are properly implemented.")
-    
-    print("\n📚 Educational Notes:")
-    print("- This script shows how to build and evaluate ML models")
-    print("- Each model demonstrates different prediction approaches")
-    print("- You can choose between sample data and real Supabase data")
-    print("- Sample data is perfect for learning and testing")
-    print("- Real data tests your actual database connection")
-    print("- The ensemble model combines multiple models for better performance")
+    print("\n🎯 Demo completed." if success else "\n❌ Demo failed; see errors above.")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,66 @@
+"""Tests for configuration loading and env-placeholder expansion."""
+
+import os
+import textwrap
+
+import pytest
+
+from src.utils.config import Config, _expand_env_placeholders
+
+
+class TestExpandEnvPlaceholders:
+    def test_uses_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CFG_TEST_HOST", raising=False)
+        assert _expand_env_placeholders("${CFG_TEST_HOST:-0.0.0.0}") == "0.0.0.0"
+
+    def test_uses_env_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("CFG_TEST_HOST", "127.0.0.1")
+        assert _expand_env_placeholders("${CFG_TEST_HOST:-0.0.0.0}") == "127.0.0.1"
+
+    def test_bare_placeholder_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CFG_TEST_BARE", raising=False)
+        assert _expand_env_placeholders("${CFG_TEST_BARE}") == ""
+
+    def test_recurses_into_dicts_and_lists(self, monkeypatch):
+        monkeypatch.setenv("CFG_TEST_PORT", "8001")
+        tree = {"api": {"port": "${CFG_TEST_PORT:-8000}", "tags": ["${CFG_TEST_PORT}"]}}
+        result = _expand_env_placeholders(tree)
+        assert result == {"api": {"port": "8001", "tags": ["8001"]}}
+
+    def test_non_string_scalars_passthrough(self):
+        assert _expand_env_placeholders(42) == 42
+        assert _expand_env_placeholders(True) is True
+
+
+class TestConfigGet:
+    def test_get_returns_expanded_value(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CFG_TEST_URL", raising=False)
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(
+            textwrap.dedent(
+                """
+                data:
+                  supabase:
+                    url: ${CFG_TEST_URL:-https://example.test}
+                api:
+                  host: ${CFG_TEST_API_HOST:-0.0.0.0}
+                """
+            )
+        )
+        config = Config(config_path=str(cfg_file))
+        # No literal "${...}" leaks through to Config.get anymore.
+        assert config.get("data.supabase.url") == "https://example.test"
+        assert config.get("api.host") == "0.0.0.0"
+
+    def test_get_reflects_environment_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CFG_TEST_URL", "https://real.supabase.co")
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("data:\n  supabase:\n    url: ${CFG_TEST_URL:-https://example.test}\n")
+        config = Config(config_path=str(cfg_file))
+        assert config.get("data.supabase.url") == "https://real.supabase.co"
+
+    def test_get_returns_default_for_missing_key(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("api:\n  host: localhost\n")
+        config = Config(config_path=str(cfg_file))
+        assert config.get("does.not.exist", "fallback") == "fallback"

--- a/tests/test_feature_ranking.py
+++ b/tests/test_feature_ranking.py
@@ -1,0 +1,116 @@
+"""Tests for the data-driven feature ranking utilities."""
+
+import numpy as np
+import pandas as pd
+
+from src.features.feature_ranking import (
+    COMPOSITE_WEIGHTS,
+    complexity_analysis,
+    complexity_level,
+    complexity_score,
+    composite_scores,
+    distribution_analysis,
+    missing_value_analysis,
+    target_correlations,
+    variance_analysis,
+)
+
+
+def _frame():
+    """Small deterministic frame with a high- and low-variance feature."""
+    return pd.DataFrame(
+        {
+            "date": pd.date_range("2023-01-01", periods=6),
+            "high_var": [0, 100, 0, 100, 0, 100],
+            "low_var": [5, 5, 5, 5, 5, 5],
+            "with_missing": [1.0, np.nan, 3.0, np.nan, 5.0, 6.0],
+            "engagement_linkedin_no_video": [10, 20, 30, 40, 50, 60],
+        }
+    )
+
+
+class TestVarianceAnalysis:
+    def test_sorted_by_variance_desc(self):
+        df = _frame()
+        result = variance_analysis(df, ["high_var", "low_var"])
+        assert [r["feature"] for r in result] == ["high_var", "low_var"]
+        assert result[0]["variance"] > result[1]["variance"]
+
+    def test_skips_non_numeric(self):
+        df = _frame()
+        df["text"] = ["a", "b", "c", "d", "e", "f"]
+        result = variance_analysis(df, ["text", "high_var"])
+        assert [r["feature"] for r in result] == ["high_var"]
+
+
+class TestMissingValueAnalysis:
+    def test_completeness_sorted_ascending(self):
+        df = _frame()
+        result = missing_value_analysis(df, ["with_missing", "high_var"])
+        # high_var has 0% missing so it comes first.
+        assert result[0]["feature"] == "high_var"
+        assert result[0]["missing_pct"] == 0.0
+        missing = next(r for r in result if r["feature"] == "with_missing")
+        assert missing["missing_count"] == 2
+        assert abs(missing["missing_pct"] - (2 / 6 * 100)) < 1e-9
+
+
+class TestDistributionAnalysis:
+    def test_returns_outlier_metrics(self):
+        df = _frame()
+        result = distribution_analysis(df, ["engagement_linkedin_no_video"])
+        assert len(result) == 1
+        entry = result[0]
+        assert "outlier_pct" in entry and "zero_variance" in entry
+        assert entry["zero_variance"] is False
+
+
+class TestComplexity:
+    def test_score_levels(self):
+        assert complexity_score("num_followers_linkedin") == 0
+        assert complexity_score("engagement_lag_1") == 2  # lag pattern
+        assert complexity_score("engagement_lag_1_scaled") == 3  # lag + scaled
+        assert complexity_level(0) == "Simple"
+        assert complexity_level(2) == "Medium"
+        assert complexity_level(3) == "Complex"
+
+    def test_analysis_sorted_simple_first(self):
+        result = complexity_analysis(["a_lag_1", "plain", "b_rolling_mean"])
+        assert result[0]["feature"] == "plain"
+        assert result[0]["complexity_score"] == 0
+
+
+class TestCompositeScores:
+    def test_weights_sum_to_one(self):
+        assert abs(sum(COMPOSITE_WEIGHTS) - 1.0) < 1e-9
+
+    def test_scores_sorted_desc_and_in_range(self):
+        df = _frame()
+        cols = ["high_var", "low_var", "with_missing", "engagement_linkedin_no_video"]
+        scores = composite_scores(df, cols)
+        assert scores, "expected at least one scored feature"
+        values = [s["composite_score"] for s in scores]
+        assert values == sorted(values, reverse=True)
+        assert all(0.0 <= v <= 1.0 for v in values)
+
+    def test_empty_when_no_numeric(self):
+        df = pd.DataFrame({"text": ["a", "b", "c"]})
+        assert composite_scores(df, ["text"]) == []
+
+
+class TestTargetCorrelations:
+    def test_perfectly_correlated_feature_ranks_first(self):
+        df = _frame()
+        # engagement is a perfect linear ramp; build a feature equal to it.
+        df["copy"] = df["engagement_linkedin_no_video"]
+        result = target_correlations(
+            df, "engagement_linkedin_no_video", ["copy", "low_var"]
+        )
+        assert result.index[0] == "copy"
+        assert abs(result.iloc[0] - 1.0) < 1e-9
+
+    def test_empty_for_non_numeric_target(self):
+        df = _frame()
+        df["cat"] = ["a", "b", "c", "d", "e", "f"]
+        result = target_correlations(df, "cat", ["high_var"])
+        assert result.empty

--- a/tests/test_model_pipeline.py
+++ b/tests/test_model_pipeline.py
@@ -1,0 +1,122 @@
+"""Tests for the reusable predictive-modeling pipeline helpers."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.models.model_pipeline import (
+    compare_model_performance,
+    create_all_models,
+    find_leakage_features,
+    prepare_modeling_data,
+    remove_data_leakage_features,
+    resolve_target_column,
+    train_all_models,
+)
+
+
+class TestLeakageRemoval:
+    def test_removes_target_derived_features(self):
+        target = "num_likes_linkedin_no_video"
+        cols = [
+            target,
+            "num_likes_linkedin_no_video_lag_1",
+            "num_likes_linkedin_no_video_rolling_mean_7",
+            "day_of_week",
+            "num_followers_linkedin",
+        ]
+        cleaned = remove_data_leakage_features(cols, target)
+        assert "num_likes_linkedin_no_video_lag_1" not in cleaned
+        assert "num_likes_linkedin_no_video_rolling_mean_7" not in cleaned
+        # Unrelated and the target itself are preserved.
+        assert "day_of_week" in cleaned
+        assert target in cleaned
+
+    def test_find_leakage_matches_removal(self):
+        target = "engagement_linkedin_no_video"
+        cols = ["engagement_linkedin_no_video_lag_3", "day_of_week"]
+        leaking = find_leakage_features(cols, target)
+        assert leaking == ["engagement_linkedin_no_video_lag_3"]
+
+
+class TestResolveTarget:
+    def test_returns_present_target(self):
+        df = pd.DataFrame({"date": [1], "num_likes_linkedin_no_video": [5]})
+        assert resolve_target_column(df, "num_likes_linkedin_no_video") == (
+            "num_likes_linkedin_no_video"
+        )
+
+    def test_falls_back_to_engagement(self):
+        df = pd.DataFrame({"date": [1], "engagement_linkedin_no_video": [5]})
+        assert resolve_target_column(df, "missing_col") == "engagement_linkedin_no_video"
+
+    def test_raises_when_no_numeric(self):
+        df = pd.DataFrame({"date": [1], "label": ["x"]})
+        with pytest.raises(ValueError):
+            resolve_target_column(df, "missing_col")
+
+
+class TestPrepareModelingData:
+    def test_splits_and_imputes(self):
+        df = pd.DataFrame(
+            {
+                "date": pd.date_range("2023-01-01", periods=4),
+                "num_likes_linkedin_no_video": [10, 20, np.nan, 40],
+                "num_likes_linkedin_no_video_lag_1": [1, 2, 3, 4],  # leakage
+                "num_followers_linkedin": [100, np.nan, 300, 400],
+            }
+        )
+        X, y, feature_cols = prepare_modeling_data(df)
+        # Leakage feature dropped, date excluded.
+        assert "num_likes_linkedin_no_video_lag_1" not in feature_cols
+        assert "date" not in feature_cols
+        assert "num_followers_linkedin" in feature_cols
+        # No missing values remain after imputation.
+        assert X.isnull().sum().sum() == 0
+        assert y.isnull().sum() == 0
+
+
+class TestCreateAndTrainModels:
+    def test_creates_full_zoo(self):
+        models = create_all_models("target", ["f1", "f2"])
+        for name in (
+            "random_forest",
+            "xgboost",
+            "lightgbm",
+            "catboost",
+            "linear_regression",
+            "ridge",
+            "mlp",
+            "svr",
+            "ensemble",
+        ):
+            assert name in models
+
+    def test_train_reports_failures_without_aborting(self):
+        # A model whose .fit raises should land in failed, not crash the run.
+        class _Boom:
+            def fit(self, X, y):
+                raise RuntimeError("boom")
+
+        class _Ok:
+            def fit(self, X, y):
+                self.fitted = True
+
+        trained, failed = train_all_models(
+            {"bad": _Boom(), "good": _Ok()}, pd.DataFrame({"a": [1]}), pd.Series([1])
+        )
+        assert "good" in trained
+        assert failed == ["bad"]
+
+
+class TestCompareModelPerformance:
+    def test_sorts_by_r2_desc(self):
+        results = {
+            "a": {"r2": 0.5, "mae": 3.0},
+            "b": {"r2": 0.9, "mae": 1.0},
+        }
+        df = compare_model_performance(results)
+        assert list(df["Model"]) == ["b", "a"]
+
+    def test_empty_results_returns_empty_frame(self):
+        assert compare_model_performance({}).empty


### PR DESCRIPTION
## Summary

Resolves #7 — the two ~1k-line demo scripts fused a teaching walkthrough with the only reusable feature/model logic, and the config layer had two half-overlapping default mechanisms.

- **Split the demos:** extract reusable feature-ranking math into `src/features/feature_ranking.py` (variance / missing / distribution / complexity / composite-score helpers + target correlations) and modeling orchestration into `src/models/model_pipeline.py` (leakage removal, target resolution, data prep, model zoo, train/evaluate/compare). Both demos are trimmed to thin narration over the importable modules (1153 → 326 and 948 → 312 lines).
- **Unify config defaults:** expand `${VAR:-default}` placeholders at YAML load and drop the redundant `_override_with_env` mechanism, so `Config.get` returns resolved values through a single path. Verified safe — the only production consumer reads a string path, so the old int/bool coercion was dead code.
- **Bundled correctness fix:** while extracting the correlation code, found and fixed a latent bug — the original `Series.corr(DataFrame)` raises on this pandas version; corrected to `DataFrame.corrwith(Series)`.

Adds unit tests for `feature_ranking`, `model_pipeline`, and `config`; updates the README's feature-test guidance to point at the renamed module.

## Validation

`& .\.venv\Scripts\python.exe -m pytest` → **36 passed** (was 7; +29 new). Both demo scripts also smoke-run end-to-end against sample data through the extracted modules (all 9 models train). The 2 numpy warnings are a benign divide-by-zero in a degenerate perfectly-correlated test fixture, not a failure.

Closes #7