### PR TITLE
fix: use scalar defaults in engagement calcs to prevent index-alignment NaN

### DIFF
--- a/src/data/data_loader.py
+++ b/src/data/data_loader.py
@@ -56,17 +56,23 @@ class DataLoader:
                 # Likes
                 likes_col = f'num_likes_{platform}_{content_type}'
                 if likes_col in df.columns:
+                    comments_col = f'num_comments_{platform}_{content_type}'
+                    reshares_col = f'num_reshares_{platform}_{content_type}'
                     df[f'engagement_{platform}_{content_type}'] = (
-                        df[likes_col].fillna(0) + 
-                        df.get(f'num_comments_{platform}_{content_type}', pd.Series(0)).fillna(0) + 
-                        df.get(f'num_reshares_{platform}_{content_type}', pd.Series(0)).fillna(0)
+                        df[likes_col].fillna(0) +
+                        (df[comments_col].fillna(0) if comments_col in df.columns else 0) +
+                        (df[reshares_col].fillna(0) if reshares_col in df.columns else 0)
                     )
-                
-                # Engagement rate (if we have follower data)
-                if f'engagement_{platform}_{content_type}' in df.columns:
+
+                # Engagement rate (computed here only when follower data is
+                # already in the posts frame; the normal path is to compute it
+                # after the profile merge in create_platform_dataset).
+                engagement_col = f'engagement_{platform}_{content_type}'
+                followers_col = f'num_followers_{platform}'
+                if engagement_col in df.columns and followers_col in df.columns:
                     df[f'engagement_rate_{platform}_{content_type}'] = (
-                        df[f'engagement_{platform}_{content_type}'] / 
-                        df.get(f'num_followers_{platform}', pd.Series(1)).fillna(1)
+                        df[engagement_col] /
+                        df[followers_col].replace(0, 1).fillna(1)
                     )
         
         # Create aggregated metrics
@@ -130,31 +136,43 @@ class DataLoader:
         """
         # Merge posts and profile data
         df = posts_df.merge(profile_df, on='date', how='left', suffixes=('', '_profile'))
-        
-        # Select platform-specific columns
-        platform_cols = ['date', 'day_of_week', 'month', 'quarter', 'year', 'is_weekend']
-        
+
+        # Compute engagement_rate after the merge so follower data is available.
+        # preprocess_posts_data only sets it when followers are already in the
+        # posts frame (rare); the standard path computes it here.
+        followers_col = f'num_followers_{platform}'
         for content_type in self.content_types:
-            # Engagement metrics
+            engagement_col = f'engagement_{platform}_{content_type}'
+            rate_col = f'engagement_rate_{platform}_{content_type}'
+            if engagement_col in df.columns and followers_col in df.columns and rate_col not in df.columns:
+                df[rate_col] = df[engagement_col] / df[followers_col].replace(0, 1).fillna(1)
+
+        # Select platform-specific columns (only those that actually exist)
+        platform_cols = ['date', 'day_of_week', 'month', 'quarter', 'year', 'is_weekend']
+
+        for content_type in self.content_types:
             engagement_col = f'engagement_{platform}_{content_type}'
             if engagement_col in df.columns:
-                platform_cols.extend([
+                for col in [
                     engagement_col,
                     f'engagement_rate_{platform}_{content_type}',
                     f'num_likes_{platform}_{content_type}',
                     f'num_comments_{platform}_{content_type}',
-                    f'num_reshares_{platform}_{content_type}'
-                ])
-        
-        # Profile metrics
-        followers_col = f'num_followers_{platform}'
+                    f'num_reshares_{platform}_{content_type}',
+                ]:
+                    if col in df.columns:
+                        platform_cols.append(col)
+
+        # Profile metrics (only those that actually exist)
         if followers_col in df.columns:
-            platform_cols.extend([
+            for col in [
                 followers_col,
                 f'follower_growth_{platform}',
-                f'follower_growth_rate_{platform}'
-            ])
-        
+                f'follower_growth_rate_{platform}',
+            ]:
+                if col in df.columns:
+                    platform_cols.append(col)
+
         platform_df = df[platform_cols].copy()
         platform_df = platform_df.dropna(subset=[col for col in platform_cols if col.startswith(f'engagement_{platform}')])
         

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -53,14 +53,54 @@ class TestDataLoader:
             'num_comments_linkedin_no_video': [10, 15],
             'num_reshares_linkedin_no_video': [5, 8]
         })
-        
+
         # Test
         processed_df = self.data_loader.preprocess_posts_data(posts_df)
-        
+
         assert 'engagement_linkedin_no_video' in processed_df.columns
         assert 'day_of_week' in processed_df.columns
         assert 'is_weekend' in processed_df.columns
         assert processed_df['engagement_linkedin_no_video'].iloc[0] == 65  # 50 + 10 + 5
+
+    def test_preprocess_posts_data_no_nan_from_missing_columns(self):
+        """Regression: pd.Series(0) default causes index-alignment NaN for all
+        rows except index 0. Using a scalar default (or column-guard) must
+        produce zero-NaN engagement columns even with a multi-row frame where
+        comments/reshares columns are absent."""
+        posts_df = pd.DataFrame({
+            'date': pd.date_range('2023-01-01', periods=5),
+            'num_likes_linkedin_no_video': [10, 20, 30, 40, 50],
+            # comments and reshares columns deliberately absent
+        })
+
+        processed_df = self.data_loader.preprocess_posts_data(posts_df)
+
+        assert 'engagement_linkedin_no_video' in processed_df.columns
+        # Every row must be non-NaN (the old pd.Series(0) default blanked rows 1-4)
+        assert processed_df['engagement_linkedin_no_video'].isna().sum() == 0
+        # Values must equal likes only (no comments/reshares to add)
+        assert list(processed_df['engagement_linkedin_no_video']) == [10, 20, 30, 40, 50]
+
+    def test_preprocess_posts_data_engagement_rate_no_nan_without_followers(self):
+        """Regression: pd.Series(1) default for missing follower column causes
+        engagement_rate to be NaN for every row except index 0. When the
+        followers column is absent the engagement_rate column must not be
+        computed at all (not silently all-zero / all-NaN via a stale default)."""
+        posts_df = pd.DataFrame({
+            'date': pd.date_range('2023-01-01', periods=4),
+            'num_likes_linkedin_no_video': [10, 20, 30, 40],
+            'num_comments_linkedin_no_video': [1, 2, 3, 4],
+            'num_reshares_linkedin_no_video': [0, 0, 0, 0],
+            # num_followers_linkedin deliberately absent
+        })
+
+        processed_df = self.data_loader.preprocess_posts_data(posts_df)
+
+        # engagement column must be present and fully populated
+        assert 'engagement_linkedin_no_video' in processed_df.columns
+        assert processed_df['engagement_linkedin_no_video'].isna().sum() == 0
+        # engagement_rate must NOT be computed when followers are absent
+        assert 'engagement_rate_linkedin_no_video' not in processed_df.columns
     
     def test_preprocess_profile_data(self):
         """Test profile data preprocessing."""


### PR DESCRIPTION
## Summary

- `preprocess_posts_data` used `df.get(col, pd.Series(0))` and `pd.Series(1)` as fallback defaults. A length-1 `[0]`-indexed Series pandas-aligns against a full-length DataFrame, setting every row except index 0 to NaN — silently degrading `engagement_*` and `engagement_rate_*` columns to mostly-NaN on every run.
- Fixed by replacing bare `pd.Series(scalar)` defaults with column-presence guards (`if col in df.columns else 0`), so missing columns contribute a clean scalar `0` with no index misalignment.
- `engagement_rate` in `preprocess_posts_data` is now guarded behind a followers-column check (follower data lives in the profile frame, never the posts frame in the normal pipeline). The rate is now always computed in `create_platform_dataset` after the profile merge, where follower data is reliably available.
- `create_platform_dataset` column selection hardened to skip absent columns instead of KeyError-ing on them.
- Two regression tests added that would have caught the `pd.Series` default bug.

## Validation

- `py_compile` on both changed files: PASS
- `pytest tests/test_data_loader.py -v`: 9/9 PASS (includes 2 new regression tests)
- `pytest -v` full suite: 38/38 PASS, 0 skips

Closes #18