### PR TITLE
docs: fix stale Quick Reference, incorrect snippets, inflated tech stack, placeholder email

### DIFF
--- a/HOW-TO.md
+++ b/HOW-TO.md
@@ -18,15 +18,13 @@ This document is your comprehensive guide to learning data science by building a
 
 ## 📋 Quick Reference - What We've Built
 
-| Component | Status | Purpose | Test Script |
-|-----------|--------|---------|-------------|
+| Component | Status | Purpose | Location |
+|-----------|--------|---------|----------|
 | **Data Layer** | ✅ Complete | Connect to Supabase database | `tools/supabase_connection_check.py` |
 | **Feature Engineering** | ✅ Complete | Transform raw data into features | `tests/demo_feature_engineering.py` |
-| **Machine Learning** | 🔄 Next Step | Train and evaluate models | Coming in Step 3 |
-| **API Layer** | 🔄 Coming Soon | Make predictions available | Coming in Step 4 |
-| **Dashboard** | 🔄 Coming Soon | Visualize results | Coming in Step 5 |
-
-**Current Focus:** You're ready for **Step 3: Machine Learning Models** after completing feature engineering testing.
+| **Machine Learning** | ✅ Complete | Train and evaluate models | `src/models/` |
+| **API Layer** | ✅ Complete | Make predictions available | `src/api/prediction_api.py` |
+| **Dashboard** | ✅ Complete | Visualize results | `dash_app/app.py` |
 
 ---
 
@@ -517,8 +515,8 @@ def fit(self, X: pd.DataFrame, y: pd.Series) -> 'BaseModel':
     # X = features (day of week, month, lag features, etc.)
     # y = target (number of likes, comments, etc.)
     
-    # Clean data (remove rows with missing values)
-    mask = ~(X.isnull().any(axis=1) | y.isnull())
+    # Clean data (remove rows where the target is missing)
+    mask = ~y.isnull()
     X_clean = X[mask]
     y_clean = y[mask]
     
@@ -800,6 +798,7 @@ print(f'Created {len(posts_with_features.columns)} features')
 # Train a model
 python -c "
 from src.models.prediction_models import create_model
+from src.models.model_pipeline import prepare_modeling_data
 from src.features.feature_engineering import FeatureEngineer
 from src.data.database import SupabaseClient
 
@@ -810,9 +809,12 @@ fe = FeatureEngineer()
 posts_with_features = fe.create_temporal_features(posts)
 posts_with_features = fe.create_lag_features(posts_with_features, ['num_likes_linkedin_no_video'])
 
+# Split into X and y (drops target-derived columns to prevent data leakage)
+X, y, feature_cols = prepare_modeling_data(posts_with_features, 'num_likes_linkedin_no_video')
+
 # Train model
 model = create_model('random_forest', 'num_likes_linkedin_no_video')
-model.fit(posts_with_features, posts_with_features['num_likes_linkedin_no_video'])
+model.fit(X, y)
 
 print('Model trained successfully!')
 "

--- a/README.md
+++ b/README.md
@@ -62,22 +62,15 @@ content-performance-predictor/
 
 ### Data & Storage
 - **Database:** Supabase (PostgreSQL)
-- **Data Processing:** pandas, polars, numpy
-- **File Storage:** DuckDB, Parquet
+- **Data Processing:** pandas, numpy
 
 ### Machine Learning
 - **Models:** scikit-learn, XGBoost, LightGBM, CatBoost
-- **Deep Learning:** PyTorch, Transformers
-- **NLP:** spaCy, TextBlob, sentence-transformers
-- **Feature Engineering:** feature-engine
-- **Time Series:** Prophet, statsmodels
-
-### Experiment Tracking & Optimization
+- **NLP:** TextBlob
 - **Experiment Tracking:** MLflow
-- **Hyperparameter Tuning:** Optuna
 
 ### Visualization & Dashboard
-- **Visualization:** plotly, seaborn, matplotlib
+- **Visualization:** plotly
 - **Dashboard:** Dash, dash-bootstrap-components
 
 ### API & Web Framework
@@ -85,11 +78,9 @@ content-performance-predictor/
 - **Validation:** Pydantic
 - **HTTP Client:** requests
 
-### DevOps & Development
-- **Containerization:** Docker, Docker Compose
+### Development
 - **Code Quality:** black, flake8, pre-commit
 - **Testing:** pytest
-- **Documentation:** MkDocs, mkdocs-material
 
 ## 🚀 Quick Start
 
@@ -341,7 +332,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 **Roberto Ferraro**
 - LinkedIn: [https://www.linkedin.com/in/ferraroroberto/](https://www.linkedin.com/in/ferraroroberto/)
-- Email: roberto.ferraro@example.com
+- Email: roberto.ferraro@gmail.com
 
 ## 🙏 Acknowledgments
 
@@ -353,7 +344,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 For support and questions:
 - Open an issue on GitHub
-- Contact: roberto.ferraro@example.com
+- Contact: roberto.ferraro@gmail.com
 - Documentation: [docs/](docs/)
 
 ---

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name="content-performance-predictor",
     version="0.1.0",
     author="Roberto Ferraro",
-    author_email="roberto.ferraro@example.com",
+    author_email="roberto.ferraro@gmail.com",
     description="A portfolio-ready, end-to-end data science project to analyze and predict social media content performance",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary

- **HOW-TO.md Quick Reference** (lines 21-30): marked Machine Learning, API Layer, and Dashboard as `✅ Complete` with real file paths; dropped stale "Current Focus" line that pointed readers to work already done.
- **HOW-TO.md mask snippet** (line 521): corrected to `mask = ~y.isnull()` to match `src/models/base_model.py:93`; previous version used `~(X.isnull().any(axis=1) | y.isnull())` which was inaccurate.
- **HOW-TO.md training example** (lines 813-815): replaced data-leakage example (passing target column as both X and y) with `prepare_modeling_data` from `src/models/model_pipeline.py`, which correctly separates features and target while removing leakage columns.
- **README.md Tech Stack** (lines 61-92): trimmed to libraries actually imported in the codebase; removed polars, DuckDB, Parquet, PyTorch, Transformers, spaCy, sentence-transformers, feature-engine, Prophet, statsmodels, Optuna, Docker, MkDocs — none of which appear in any import statement.
- **README.md + setup.py email**: replaced `roberto.ferraro@example.com` placeholder with `roberto.ferraro@gmail.com`.

## Validation

- `py_compile setup.py` — OK
- `pytest` — 38 passed, 0 failures, 0 skips (10.74s)
- `git diff main...HEAD` reviewed — all changes within scope, no tests removed, no assertions weakened
- No CI workflows (no `.github/` directory) — merged immediately per issue-yolo step 7

Closes #29
