### PR TITLE
fix: stabilize categorical encoding across fit and predict

### DIFF
--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -34,22 +34,35 @@ class BaseModel(ABC, BaseEstimator):
         self.is_fitted = False
         self.metrics = {}
         self.feature_importance = {}
+        # Categorical encoding state captured at fit time and reused at predict
+        # time so a given string always maps to the same integer code.
+        self._cat_categories: Dict[str, pd.Index] = {}
         
     @abstractmethod
     def _create_model(self) -> Any:
         """Create the underlying model instance."""
         pass
     
-    @staticmethod
-    def _clean_features(X: pd.DataFrame) -> pd.DataFrame:
+    def _clean_features(self, X: pd.DataFrame, fit: bool = False) -> pd.DataFrame:
         """
         Apply per-column type handling used identically at fit time and predict time.
 
         Numeric columns: fill missing values with median (fallback 0).
-        Other columns: fill missing with 'missing', then encode as Categorical codes.
+        Other columns: fill missing with 'missing', then encode as Categorical codes
+        using a fixed category mapping learned at fit time.
+
+        The category mapping for each non-numeric column is captured on ``self`` the
+        first time the column is seen (``fit=True``) and reused on every subsequent
+        call (``fit=False``). This keeps a given string mapped to the same integer
+        code across train and predict — encoding it independently per call (the old
+        behaviour) let the same value get a different code whenever the set of values
+        present in the input changed. Values unseen at fit time encode to ``-1``,
+        pandas' standard "not in categories" sentinel.
 
         Args:
             X: Feature DataFrame (a copy is made internally).
+            fit: When True, learn and store each non-numeric column's categories on
+                ``self._cat_categories``. When False, reuse the stored categories.
 
         Returns:
             Cleaned DataFrame ready for the underlying sklearn estimator.
@@ -63,9 +76,18 @@ class BaseModel(ABC, BaseEstimator):
                     median_val = 0
                 X_clean[col] = X_clean[col].fillna(median_val)
             else:
-                # For categorical/string columns, encode all values as categories
-                X_clean[col] = X_clean[col].fillna('missing')
-                X_clean[col] = pd.Categorical(X_clean[col]).codes
+                # For categorical/string columns, encode against a stable mapping.
+                filled = X_clean[col].fillna('missing')
+                if fit:
+                    categories = pd.Categorical(filled)
+                    self._cat_categories[col] = categories.categories
+                    X_clean[col] = categories.codes
+                else:
+                    # Reuse the fitted categories so codes stay consistent. Fall back
+                    # to per-call categories only if the column was never seen at fit
+                    # time (e.g. a column absent from training).
+                    categories = self._cat_categories.get(col)
+                    X_clean[col] = pd.Categorical(filled, categories=categories).codes
         return X_clean
 
     def fit(self, X: pd.DataFrame, y: pd.Series) -> 'BaseModel':
@@ -86,8 +108,8 @@ class BaseModel(ABC, BaseEstimator):
         if self.feature_columns:
             X = X[self.feature_columns]
 
-        # Handle different column types
-        X_clean = self._clean_features(X)
+        # Handle different column types — learn the categorical mapping here.
+        X_clean = self._clean_features(X, fit=True)
 
         # Remove any rows with missing target values
         mask = ~y.isnull()
@@ -125,8 +147,8 @@ class BaseModel(ABC, BaseEstimator):
         if self.feature_columns:
             X = X[self.feature_columns]
 
-        # Handle different column types (same logic as fit — delegates to _clean_features)
-        X_clean = self._clean_features(X)
+        # Handle different column types — reuse the categorical mapping learned at fit.
+        X_clean = self._clean_features(X, fit=False)
 
         try:
             predictions = self.model.predict(X_clean)
@@ -211,9 +233,10 @@ class BaseModel(ABC, BaseEstimator):
             'model': self.model,
             'is_fitted': self.is_fitted,
             'metrics': self.metrics,
-            'feature_importance': self.feature_importance
+            'feature_importance': self.feature_importance,
+            'cat_categories': self._cat_categories
         }
-        
+
         joblib.dump(model_data, filepath)
         logger.info(f"Model saved to {filepath}")
     
@@ -245,7 +268,10 @@ class BaseModel(ABC, BaseEstimator):
         instance.is_fitted = model_data['is_fitted']
         instance.metrics = model_data['metrics']
         instance.feature_importance = model_data['feature_importance']
-        
+        # Restore categorical encoding mapping (absent in models saved before this
+        # field existed → empty dict, matching the pre-fit default).
+        instance._cat_categories = model_data.get('cat_categories', {})
+
         logger.info(f"Model loaded from {filepath}")
         return instance
     

--- a/tests/test_base_model_encoding.py
+++ b/tests/test_base_model_encoding.py
@@ -1,0 +1,111 @@
+"""Tests for stable categorical encoding in BaseModel (issue #28).
+
+The fit/predict contract is that a non-numeric feature value encodes to the
+same integer code at predict time as it did at fit time. Encoding each call
+independently (the old bug) let the same string map to a different code
+whenever the set of values present in the input changed.
+"""
+
+import numpy as np
+import pandas as pd
+
+from src.models.base_model import BaseModel
+
+
+class _RecordingEstimator:
+    """Minimal sklearn-shaped estimator that records the X it receives."""
+
+    def __init__(self):
+        self.seen_fit_X = None
+        self.seen_predict_X = None
+
+    def fit(self, X, y):
+        self.seen_fit_X = X.copy()
+        return self
+
+    def predict(self, X):
+        self.seen_predict_X = X.copy()
+        return np.zeros(len(X))
+
+
+class _SimpleModel(BaseModel):
+    """Concrete BaseModel wired to the recording estimator for tests.
+
+    Keeps the base ``__init__`` signature so ``BaseModel.load_model`` can
+    reconstruct it via ``cls(model_name=..., target_column=..., ...)``.
+    """
+
+    def __init__(self, model_name="simple", target_column="y", feature_columns=None):
+        super().__init__(
+            model_name=model_name,
+            target_column=target_column,
+            feature_columns=feature_columns,
+        )
+
+    def _create_model(self):
+        return _RecordingEstimator()
+
+
+def _encoded_value(seen_X, col, row=0):
+    return int(seen_X[col].iloc[row])
+
+
+def test_same_category_encodes_identically_train_and_predict():
+    # Training rows carry both categories; "no_video" sorts before "video",
+    # so under the old per-call encoding "video" -> 1 at fit.
+    train = pd.DataFrame(
+        {
+            "content_type": ["video", "no_video", "video", "no_video"],
+            "num_followers": [100, 200, 300, 400],
+        }
+    )
+    y = pd.Series([1.0, 2.0, 3.0, 4.0])
+
+    model = _SimpleModel(feature_columns=["content_type", "num_followers"])
+    model.fit(train, y)
+    fit_code_video = _encoded_value(model.model.seen_fit_X, "content_type", row=0)
+
+    # A single-row predict frame containing only "video". Encoding it in
+    # isolation (the bug) would map "video" -> 0 (the only/alphabetically-first
+    # value present), silently flipping it to "no_video"'s code.
+    predict_one = pd.DataFrame({"content_type": ["video"], "num_followers": [123]})
+    model.predict(predict_one)
+    predict_code_video = _encoded_value(model.model.seen_predict_X, "content_type", row=0)
+
+    assert predict_code_video == fit_code_video
+
+
+def test_unseen_category_encodes_to_minus_one():
+    train = pd.DataFrame(
+        {"content_type": ["video", "no_video"], "num_followers": [100, 200]}
+    )
+    y = pd.Series([1.0, 2.0])
+
+    model = _SimpleModel(feature_columns=["content_type", "num_followers"])
+    model.fit(train, y)
+
+    predict = pd.DataFrame({"content_type": ["carousel"], "num_followers": [50]})
+    model.predict(predict)
+    assert _encoded_value(model.model.seen_predict_X, "content_type", row=0) == -1
+
+
+def test_categories_survive_save_and_load(tmp_path):
+    train = pd.DataFrame(
+        {
+            "content_type": ["video", "no_video", "video"],
+            "num_followers": [100, 200, 300],
+        }
+    )
+    y = pd.Series([1.0, 2.0, 3.0])
+
+    model = _SimpleModel(feature_columns=["content_type", "num_followers"])
+    model.fit(train, y)
+    fit_code_video = _encoded_value(model.model.seen_fit_X, "content_type", row=0)
+
+    path = str(tmp_path / "model.joblib")
+    model.save_model(path)
+    reloaded = _SimpleModel.load_model(path)
+
+    predict_one = pd.DataFrame({"content_type": ["video"], "num_followers": [1]})
+    reloaded.predict(predict_one)
+    assert _encoded_value(reloaded.model.seen_predict_X, "content_type", row=0) == fit_code_video


### PR DESCRIPTION
## Summary

Fixes the latent encoding bug in #28. `BaseModel._clean_features` previously re-encoded categorical columns independently at fit and predict time via `pd.Categorical(X[col]).codes`, which assigns integer codes from the unique values *present in that call* — so the same string could map to a different code at train vs predict (e.g. a single-row predict frame containing only `"video"` would code it `0`, the model reading it as `"no_video"`).

- `_clean_features` is now an instance method taking `fit: bool`. At fit it learns and stores each non-numeric column's category mapping on `self._cat_categories`; at predict it re-applies the stored mapping, so a given string always maps to the same code.
- Unseen-at-fit categories now encode to `-1` (pandas' standard out-of-categories sentinel) rather than being silently re-coded.
- `save_model`/`load_model` persist and restore `cat_categories` (backward-compatible default for models saved before this change) so a reloaded model keeps stable encodings.

## Validation

Local gate green: `py_compile` clean, `pytest` 41 passed (3 new encoding tests + 38 existing). No ruff config in repo; no CI workflow. The bug is latent today (only numeric features flow through the live pipeline), so no behavior change for current production paths.

Closes #28