### PR TITLE
refactor: single-source platform vocabulary and cross-platform feature math

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ content-performance-predictor/
 │   │   └── prediction_api.py  # REST API
 │   ├── utils/                 # Utilities
 │   │   └── config.py          # Configuration management
+│   ├── constants.py           # Canonical platform / content-type vocabulary
 │   └── cli.py                 # Command-line interface
 ├── dash_app/                  # Dashboard app (Dash)
 │   └── app.py                 # Dash application

--- a/dash_app/app.py
+++ b/dash_app/app.py
@@ -12,9 +12,22 @@ from datetime import datetime, timedelta, date
 import requests
 import json
 import os
+import sys
+from pathlib import Path
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# This module is launched as a script (``python dash_app/app.py``), so only its
+# own directory is on sys.path. Put the repo root on the path so the dashboard
+# shares the project's single source of truth for the platform/content-type
+# vocabulary instead of re-listing it here.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from src.constants import PLATFORMS, CONTENT_TYPES, platform_label, content_type_label
+
+# Dropdown option lists, built once from the canonical vocabulary.
+PLATFORM_OPTIONS = [{"label": platform_label(p), "value": p} for p in PLATFORMS]
+CONTENT_TYPE_OPTIONS = [{"label": content_type_label(c), "value": c} for c in CONTENT_TYPES]
 
 # Initialize Dash app
 app = dash.Dash(
@@ -63,13 +76,7 @@ prediction_layout = dbc.Row([
                         dbc.Label("Platform"),
                         dcc.Dropdown(
                             id="platform-dropdown",
-                            options=[
-                                {"label": "LinkedIn", "value": "linkedin"},
-                                {"label": "Instagram", "value": "instagram"},
-                                {"label": "Twitter", "value": "twitter"},
-                                {"label": "Substack", "value": "substack"},
-                                {"label": "Threads", "value": "threads"}
-                            ],
+                            options=PLATFORM_OPTIONS,
                             value="linkedin"
                         )
                     ], width=6),
@@ -77,10 +84,7 @@ prediction_layout = dbc.Row([
                         dbc.Label("Content Type"),
                         dcc.Dropdown(
                             id="content-type-dropdown",
-                            options=[
-                                {"label": "No Video", "value": "no_video"},
-                                {"label": "Video", "value": "video"}
-                            ],
+                            options=CONTENT_TYPE_OPTIONS,
                             value="no_video"
                         )
                     ], width=6)
@@ -134,13 +138,7 @@ times_layout = dbc.Row([
                         dbc.Label("Platform"),
                         dcc.Dropdown(
                             id="times-platform-dropdown",
-                            options=[
-                                {"label": "LinkedIn", "value": "linkedin"},
-                                {"label": "Instagram", "value": "instagram"},
-                                {"label": "Twitter", "value": "twitter"},
-                                {"label": "Substack", "value": "substack"},
-                                {"label": "Threads", "value": "threads"}
-                            ],
+                            options=PLATFORM_OPTIONS,
                             value="linkedin"
                         )
                     ], width=6),
@@ -148,11 +146,7 @@ times_layout = dbc.Row([
                         dbc.Label("Content Type"),
                         dcc.Dropdown(
                             id="times-content-type-dropdown",
-                            options=[
-                                {"label": "All", "value": None},
-                                {"label": "No Video", "value": "no_video"},
-                                {"label": "Video", "value": "video"}
-                            ],
+                            options=[{"label": "All", "value": None}] + CONTENT_TYPE_OPTIONS,
                             value=None
                         )
                     ], width=6)
@@ -175,13 +169,7 @@ trends_layout = dbc.Row([
                         dbc.Label("Platform"),
                         dcc.Dropdown(
                             id="trends-platform-dropdown",
-                            options=[
-                                {"label": "LinkedIn", "value": "linkedin"},
-                                {"label": "Instagram", "value": "instagram"},
-                                {"label": "Twitter", "value": "twitter"},
-                                {"label": "Substack", "value": "substack"},
-                                {"label": "Threads", "value": "threads"}
-                            ],
+                            options=PLATFORM_OPTIONS,
                             value="linkedin"
                         )
                     ], width=6),

--- a/src/cli.py
+++ b/src/cli.py
@@ -11,6 +11,7 @@ from .data.data_loader import DataLoader
 from .features.feature_engineering import FeatureEngineer
 from .models.prediction_models import create_model
 from .utils.config import get_config
+from .constants import PLATFORMS, CONTENT_TYPES
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -183,8 +184,7 @@ def analyze_data(args):
         logger.info(f"  Date range: {posts_df['date'].min()} to {posts_df['date'].max()}")
         
         # Platform analysis
-        platforms = ['linkedin', 'instagram', 'twitter', 'substack', 'threads']
-        for platform in platforms:
+        for platform in PLATFORMS:
             engagement_cols = [col for col in posts_df.columns if f'engagement_{platform}' in col]
             if engagement_cols:
                 total_engagement = posts_df[engagement_cols].sum().sum()
@@ -220,9 +220,9 @@ Examples:
     
     # Train command
     train_parser = subparsers.add_parser('train', help='Train a model')
-    train_parser.add_argument('--platform', choices=['linkedin', 'instagram', 'twitter', 'substack', 'threads'],
+    train_parser.add_argument('--platform', choices=PLATFORMS,
                              help='Platform to train for')
-    train_parser.add_argument('--content-type', choices=['no_video', 'video'], default='no_video',
+    train_parser.add_argument('--content-type', choices=CONTENT_TYPES, default='no_video',
                              help='Content type')
     train_parser.add_argument('--model-type', 
                              choices=['random_forest', 'xgboost', 'lightgbm', 'catboost', 'linear_regression'],
@@ -232,9 +232,9 @@ Examples:
     
     # Predict command
     predict_parser = subparsers.add_parser('predict', help='Make predictions')
-    predict_parser.add_argument('--platform', choices=['linkedin', 'instagram', 'twitter', 'substack', 'threads'],
+    predict_parser.add_argument('--platform', choices=PLATFORMS,
                                help='Platform to predict for')
-    predict_parser.add_argument('--content-type', choices=['no_video', 'video'], default='no_video',
+    predict_parser.add_argument('--content-type', choices=CONTENT_TYPES, default='no_video',
                                help='Content type')
     predict_parser.add_argument('--model-type', 
                                choices=['random_forest', 'xgboost', 'lightgbm', 'catboost', 'linear_regression'],

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,45 @@
+"""Canonical vocabulary for platforms and content types.
+
+Single source of truth for the set of social platforms and content types the
+project understands. Values are read from ``config.yaml`` (``data.platforms`` /
+``data.content_types``) so the vocabulary can be changed in one place; the
+literals here are only a fallback used when the config file is absent. Import
+``PLATFORMS`` / ``CONTENT_TYPES`` (and the ``*_label`` helpers for UI) instead of
+re-literalling these lists anywhere in the codebase.
+"""
+
+from typing import Dict, List
+
+from .utils.config import get_config
+
+_config = get_config()
+
+PLATFORMS: List[str] = list(
+    _config.get("data.platforms")
+    or ["linkedin", "instagram", "twitter", "substack", "threads"]
+)
+
+CONTENT_TYPES: List[str] = list(
+    _config.get("data.content_types") or ["no_video", "video"]
+)
+
+# Human-facing labels for UI dropdowns. A name like "LinkedIn" cannot be derived
+# from ``str.title()`` (which yields "Linkedin"), so display strings live here in
+# one place; an unknown platform falls back to a title-cased value.
+_PLATFORM_LABELS: Dict[str, str] = {
+    "linkedin": "LinkedIn",
+    "instagram": "Instagram",
+    "twitter": "Twitter",
+    "substack": "Substack",
+    "threads": "Threads",
+}
+
+
+def platform_label(platform: str) -> str:
+    """Return the display label for a platform value."""
+    return _PLATFORM_LABELS.get(platform, platform.replace("_", " ").title())
+
+
+def content_type_label(content_type: str) -> str:
+    """Return the display label for a content-type value."""
+    return content_type.replace("_", " ").title()

--- a/src/data/data_loader.py
+++ b/src/data/data_loader.py
@@ -6,18 +6,20 @@ from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime, timedelta
 import logging
 from .database import SupabaseClient
+from ..constants import PLATFORMS, CONTENT_TYPES
+from ..features.feature_engineering import add_cross_platform_engagement_features
 
 logger = logging.getLogger(__name__)
 
 
 class DataLoader:
     """Data loader for content performance prediction."""
-    
+
     def __init__(self, supabase_client: Optional[SupabaseClient] = None):
         """Initialize data loader."""
         self.supabase_client = supabase_client or SupabaseClient()
-        self.platforms = ['linkedin', 'instagram', 'twitter', 'substack', 'threads']
-        self.content_types = ['no_video', 'video']
+        self.platforms = list(PLATFORMS)
+        self.content_types = list(CONTENT_TYPES)
         
     def load_consolidated_data(self, start_date: Optional[str] = None, end_date: Optional[str] = None) -> Tuple[pd.DataFrame, pd.DataFrame]:
         """
@@ -191,29 +193,14 @@ class DataLoader:
             Cross-platform dataset
         """
         df = posts_df.merge(profile_df, on='date', how='left', suffixes=('', '_profile'))
-        
-        # Create cross-platform features
-        for content_type in self.content_types:
-            engagement_cols = [f'engagement_{platform}_{content_type}' for platform in self.platforms]
-            available_cols = [col for col in engagement_cols if col in df.columns]
-            
-            if available_cols:
-                df[f'total_engagement_{content_type}'] = df[available_cols].sum(axis=1)
-                df[f'avg_engagement_{content_type}'] = df[available_cols].mean(axis=1)
-                df[f'max_engagement_{content_type}'] = df[available_cols].max(axis=1)
-                df[f'engagement_std_{content_type}'] = df[available_cols].std(axis=1)
-        
-        # Platform comparison features
-        for platform in self.platforms:
-            for content_type in self.content_types:
-                engagement_col = f'engagement_{platform}_{content_type}'
-                if engagement_col in df.columns:
-                    total_engagement_col = f'total_engagement_{content_type}'
-                    if total_engagement_col in df.columns:
-                        df[f'{platform}_share_{content_type}'] = (
-                            df[engagement_col] / df[total_engagement_col].replace(0, 1)
-                        )
-        
+
+        # The cross-platform aggregation math (total/avg/max/std + per-platform
+        # share) lives in exactly one place — the shared helper in
+        # feature_engineering — so the two entry points cannot drift.
+        df = add_cross_platform_engagement_features(
+            df, platforms=self.platforms, content_types=self.content_types
+        )
+
         logger.info(f"Created cross-platform dataset with {len(df)} records")
         return df
     

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -10,8 +10,60 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 import re
 import nltk
 from textblob import TextBlob
+from ..constants import PLATFORMS, CONTENT_TYPES
 
 logger = logging.getLogger(__name__)
+
+
+def add_cross_platform_engagement_features(
+    df: pd.DataFrame,
+    platforms: Optional[List[str]] = None,
+    content_types: Optional[List[str]] = None,
+) -> pd.DataFrame:
+    """Add cross-platform engagement aggregations to ``df`` in place-safe form.
+
+    Computes, per content type, the ``total_/avg_/max_/engagement_std_`` columns
+    across platforms and the per-platform ``{platform}_share_{content_type}``
+    ratio. This is the single implementation of that math; both
+    ``FeatureEngineer.create_cross_platform_features`` and
+    ``DataLoader.create_cross_platform_dataset`` delegate here so the two paths
+    cannot diverge.
+
+    Args:
+        df: Input DataFrame containing ``engagement_{platform}_{content_type}``
+            columns.
+        platforms: Platforms to aggregate over (defaults to ``PLATFORMS``).
+        content_types: Content types to aggregate over (defaults to
+            ``CONTENT_TYPES``).
+
+    Returns:
+        A new DataFrame with the cross-platform engagement columns added.
+    """
+    df = df.copy()
+    platforms = platforms if platforms is not None else PLATFORMS
+    content_types = content_types if content_types is not None else CONTENT_TYPES
+
+    for content_type in content_types:
+        engagement_cols = [f'engagement_{platform}_{content_type}' for platform in platforms]
+        available_cols = [col for col in engagement_cols if col in df.columns]
+
+        if available_cols:
+            df[f'total_engagement_{content_type}'] = df[available_cols].sum(axis=1)
+            df[f'avg_engagement_{content_type}'] = df[available_cols].mean(axis=1)
+            df[f'max_engagement_{content_type}'] = df[available_cols].max(axis=1)
+            df[f'engagement_std_{content_type}'] = df[available_cols].std(axis=1)
+
+            # Platform share of total engagement
+            for platform in platforms:
+                col = f'engagement_{platform}_{content_type}'
+                if col in df.columns:
+                    # Handle division by zero and missing values
+                    df[f'{platform}_share_{content_type}'] = (
+                        df[col] / df[f'total_engagement_{content_type}'].replace(0, 1)
+                    )
+                    df[f'{platform}_share_{content_type}'] = df[f'{platform}_share_{content_type}'].fillna(0)
+
+    return df
 
 
 class FeatureEngineer:
@@ -127,21 +179,21 @@ class FeatureEngineer:
         df = df.copy()
         
         if platforms is None:
-            platforms = ['linkedin', 'instagram', 'twitter', 'substack', 'threads']
-        
+            platforms = PLATFORMS
+
         for platform in platforms:
             # Engagement rate features
             engagement_cols = [col for col in df.columns if col.startswith(f'engagement_{platform}')]
             follower_col = f'num_followers_{platform}'
-            
+
             if engagement_cols and follower_col in df.columns:
                 for col in engagement_cols:
                     # Handle division by zero and missing values
                     df[f'{col}_rate'] = df[col] / df[follower_col].replace(0, 1)
                     df[f'{col}_rate'] = df[f'{col}_rate'].fillna(0)
-            
+
             # Engagement ratio features
-            for content_type in ['no_video', 'video']:
+            for content_type in CONTENT_TYPES:
                 likes_col = f'num_likes_{platform}_{content_type}'
                 comments_col = f'num_comments_{platform}_{content_type}'
                 shares_col = f'num_reshares_{platform}_{content_type}'
@@ -173,34 +225,12 @@ class FeatureEngineer:
         Returns:
             DataFrame with cross-platform features
         """
-        df = df.copy()
-        
-        platforms = ['linkedin', 'instagram', 'twitter', 'substack', 'threads']
-        content_types = ['no_video', 'video']
-        
-        for content_type in content_types:
-            # Total engagement across platforms
-            engagement_cols = [f'engagement_{platform}_{content_type}' for platform in platforms]
-            available_cols = [col for col in engagement_cols if col in df.columns]
-            
-            if available_cols:
-                df[f'total_engagement_{content_type}'] = df[available_cols].sum(axis=1)
-                df[f'avg_engagement_{content_type}'] = df[available_cols].mean(axis=1)
-                df[f'max_engagement_{content_type}'] = df[available_cols].max(axis=1)
-                df[f'engagement_std_{content_type}'] = df[available_cols].std(axis=1)
-                
-                # Platform share
-                for platform in platforms:
-                    col = f'engagement_{platform}_{content_type}'
-                    if col in df.columns:
-                        # Handle division by zero and missing values
-                        df[f'{platform}_share_{content_type}'] = (
-                            df[col] / df[f'total_engagement_{content_type}'].replace(0, 1)
-                        )
-                        df[f'{platform}_share_{content_type}'] = df[f'{platform}_share_{content_type}'].fillna(0)
-        
+        # Engagement aggregations (total/avg/max/std + share) come from the one
+        # shared implementation so this path and DataLoader cannot drift.
+        df = add_cross_platform_engagement_features(df)
+
         # Cross-platform follower features
-        follower_cols = [f'num_followers_{platform}' for platform in platforms]
+        follower_cols = [f'num_followers_{platform}' for platform in PLATFORMS]
         available_follower_cols = [col for col in follower_cols if col in df.columns]
         
         if available_follower_cols:
@@ -262,11 +292,9 @@ class FeatureEngineer:
             DataFrame with interaction features
         """
         df = df.copy()
-        
-        platforms = ['linkedin', 'instagram', 'twitter', 'substack', 'threads']
-        
-        for platform in platforms:
-            for content_type in ['no_video', 'video']:
+
+        for platform in PLATFORMS:
+            for content_type in CONTENT_TYPES:
                 likes_col = f'num_likes_{platform}_{content_type}'
                 comments_col = f'num_comments_{platform}_{content_type}'
                 shares_col = f'num_reshares_{platform}_{content_type}'


### PR DESCRIPTION
## Summary

Resolves both duplication findings from the audit:

- **Cross-platform aggregation existed twice** (`data_loader.py` and `feature_engineering.py`). The engagement math is now one helper, `add_cross_platform_engagement_features`; `DataLoader.create_cross_platform_dataset` delegates to it.
- **Platform / content-type lists were re-literal'd in ~8 sites** while `config.yaml`'s `data.platforms` / `data.content_types` sat unused. A new `src/constants.py` is the single source of truth — it reads the config (literal fallback) and is imported by `feature_engineering`, `data_loader`, `cli` (including argparse `choices`), and the `dash_app` dropdowns.

## Notes for review

- Both cross-platform paths now route through one helper, so `DataLoader`'s output gains `fillna(0)` on the `{platform}_share_*` columns (previously only `FeatureEngineer` did this) — a consistency improvement, not a regression.
- The package isn't installed editable, so `python dash_app/app.py` only has `dash_app/` on `sys.path`; a small documented `sys.path` bootstrap lets the decoupled dashboard import the canonical `src.constants` rather than re-listing the vocabulary.
- Single defaults (`default='no_video'`, widget `value="linkedin"`) left as-is — single selections, not re-listed vocabulary.

## Validation

`pytest` — 41 passed (2 pre-existing numpy warnings, unrelated). No CI workflow in this repo; the local gate is the contract.

Closes #16