### PR TITLE
chore: add missing type hints across cli and model layer

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -18,7 +18,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def setup_logging(verbose: bool = False):
+def setup_logging(verbose: bool = False) -> None:
     """Set up logging configuration."""
     level = logging.DEBUG if verbose else logging.INFO
     logging.basicConfig(
@@ -27,7 +27,7 @@ def setup_logging(verbose: bool = False):
     )
 
 
-def train_model(args):
+def train_model(args: argparse.Namespace) -> int:
     """Train a model."""
     try:
         # Load configuration
@@ -122,7 +122,7 @@ def train_model(args):
         return 1
 
 
-def predict(args):
+def predict(args: argparse.Namespace) -> int:
     """Make predictions."""
     try:
         # Load configuration
@@ -159,7 +159,7 @@ def predict(args):
         return 1
 
 
-def analyze_data(args):
+def analyze_data(args: argparse.Namespace) -> int:
     """Analyze data."""
     try:
         # Initialize components
@@ -197,7 +197,7 @@ def analyze_data(args):
         return 1
 
 
-def main():
+def main() -> int:
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
         description="Content Performance Predictor CLI",

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -165,7 +165,7 @@ class FeatureEngineer:
         logger.info(f"Created lag features for {len(target_cols)} columns with lags {lags}")
         return df
     
-    def create_engagement_features(self, df: pd.DataFrame, platforms: List[str] = None) -> pd.DataFrame:
+    def create_engagement_features(self, df: pd.DataFrame, platforms: Optional[List[str]] = None) -> pd.DataFrame:
         """
         Create engagement-related features.
         

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class BaseModel(ABC, BaseEstimator):
     """Base class for all content performance prediction models."""
     
-    def __init__(self, model_name: str, target_column: str, feature_columns: List[str] = None):
+    def __init__(self, model_name: str, target_column: str, feature_columns: Optional[List[str]] = None):
         """
         Initialize base model.
         

--- a/src/models/prediction_models.py
+++ b/src/models/prediction_models.py
@@ -28,7 +28,7 @@ lgb.register_logger(SilentLogger())
 class RandomForestModel(BaseModel):
     """Random Forest model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize Random Forest model.
         
@@ -55,7 +55,7 @@ class RandomForestModel(BaseModel):
 class XGBoostModel(BaseModel):
     """XGBoost model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize XGBoost model.
         
@@ -83,7 +83,7 @@ class XGBoostModel(BaseModel):
 class LightGBMModel(BaseModel):
     """LightGBM model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize LightGBM model.
         
@@ -111,7 +111,7 @@ class LightGBMModel(BaseModel):
 class CatBoostModel(BaseModel):
     """CatBoost model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize CatBoost model.
         
@@ -139,7 +139,7 @@ class CatBoostModel(BaseModel):
 class LinearRegressionModel(BaseModel):
     """Linear Regression model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize Linear Regression model.
         
@@ -163,7 +163,7 @@ class LinearRegressionModel(BaseModel):
 class RidgeModel(BaseModel):
     """Ridge Regression model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize Ridge Regression model.
         
@@ -188,7 +188,7 @@ class RidgeModel(BaseModel):
 class SVRModel(BaseModel):
     """Support Vector Regression model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize SVR model.
         
@@ -214,7 +214,7 @@ class SVRModel(BaseModel):
 class MLPModel(BaseModel):
     """Multi-layer Perceptron model for content performance prediction."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, **kwargs):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs):
         """
         Initialize MLP model.
         
@@ -244,8 +244,8 @@ class MLPModel(BaseModel):
 class EnsembleModel(BaseModel):
     """Ensemble model combining multiple base models."""
     
-    def __init__(self, target_column: str, feature_columns: List[str] = None, 
-                 base_models: List[BaseModel] = None, weights: List[float] = None):
+    def __init__(self, target_column: str, feature_columns: Optional[List[str]] = None,
+                 base_models: Optional[List[BaseModel]] = None, weights: Optional[List[float]] = None):
         """
         Initialize Ensemble model.
         
@@ -356,7 +356,7 @@ class EnsembleModel(BaseModel):
         return all_metrics
 
 
-def create_model(model_type: str, target_column: str, feature_columns: List[str] = None, **kwargs) -> BaseModel:
+def create_model(model_type: str, target_column: str, feature_columns: Optional[List[str]] = None, **kwargs) -> BaseModel:
     """
     Factory function to create models.
     


### PR DESCRIPTION
## Summary

- Annotate all public functions in `src/cli.py` (`setup_logging`, `train_model`, `predict`, `analyze_data`, `main`) with parameter types (`argparse.Namespace`) and return types (`int` / `None`)
- Fix `List[str] = None` -> `Optional[List[str]] = None` in `BaseModel.__init__` (`base_model.py`)
- Apply the same fix to all nine model `__init__` signatures and the `create_model` factory in `prediction_models.py`; also fix `EnsembleModel`'s `base_models` and `weights` parameters
- Fix `List[str] = None` -> `Optional[List[str]] = None` in `FeatureEngineer.create_engagement_features` (`feature_engineering.py`)

## Validation

- Syntax: `py_compile` on all 4 changed files -- OK
- Tests: `pytest tests/` -- 41 passed, 0 failed, 0 skipped
- Diff sweep: only the 4 target files touched, no unintended changes

Closes #17