### PR TITLE
fix: stop /predict papering over missing models and data

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -65,7 +65,7 @@ features:
     window_sizes: [7, 14, 30]
   
   scaling:
-    method: standard  # standard, minmax
+    method: standard  # z-score (StandardScaler)
   
   importance_threshold: 0.01
 

--- a/src/api/prediction_api.py
+++ b/src/api/prediction_api.py
@@ -211,27 +211,36 @@ async def predict_engagement(request: PredictionRequest):
         prediction_data = posts_df[posts_df['date'] == prediction_date].copy()
         
         if prediction_data.empty:
-            # Create synthetic data for prediction
-            prediction_data = pd.DataFrame([{
-                'date': prediction_date,
-                'day_of_week': prediction_date.dayofweek,
-                'month': prediction_date.month,
-                'quarter': prediction_date.quarter,
-                'year': prediction_date.year,
-                'is_weekend': 1 if prediction_date.dayofweek in [5, 6] else 0
-            }])
+            # Never fabricate a synthetic 6-column row: every model was trained
+            # on the full feature set (model.feature_columns), so a partial row
+            # would KeyError in BaseModel.predict or feed the model the wrong
+            # feature shape. Surface the missing data instead of papering over it.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"No data available for {request.date} to build a prediction "
+                    "feature row. Request a date present in the recent posts history."
+                ),
+            )
         
         # Add additional features if provided
         if request.features:
             for key, value in request.features.items():
                 prediction_data[key] = value
         
-        # Select appropriate model
+        # Select the model trained for this platform/content type. Never silently
+        # substitute an unrelated model — that returns wrong-looking-right output
+        # under the caller's requested key, which is worse than failing.
         model_key = f"{request.platform}_{request.content_type}"
         if model_key not in models:
-            # Use a default model
-            model_key = list(models.keys())[0]
-        
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"No trained model for {request.platform}/{request.content_type}. "
+                    f"Available models: {sorted(models.keys())}"
+                ),
+            )
+
         model = models[model_key]
         
         # Make prediction
@@ -247,6 +256,8 @@ async def predict_engagement(request: PredictionRequest):
             features_used=model.feature_columns or []
         )
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in prediction: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -309,6 +320,8 @@ async def analyze_caption(request: CaptionAnalysisRequest):
             recommendations=recommendations
         )
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in caption analysis: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -369,6 +382,8 @@ async def get_best_posting_times(request: BestTimeRequest):
             analysis_period=f"Last {request.days_ahead + 30} days"
         )
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in best times analysis: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -436,6 +451,8 @@ async def get_platform_trends(request: PlatformTrendRequest):
             recommendations=recommendations
         )
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in platform trends analysis: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -5,7 +5,7 @@ import numpy as np
 from typing import Dict, List, Optional, Tuple, Any
 from datetime import datetime, timedelta
 import logging
-from sklearn.preprocessing import StandardScaler, MinMaxScaler
+from sklearn.preprocessing import StandardScaler
 import re
 from textblob import TextBlob
 from ..constants import PLATFORMS, CONTENT_TYPES
@@ -356,26 +356,25 @@ class FeatureEngineer:
         logger.info("Created trend features")
         return df
     
-    def scale_features(self, df: pd.DataFrame, feature_cols: List[str], scaler_type: str = 'standard') -> pd.DataFrame:
+    def scale_features(self, df: pd.DataFrame, feature_cols: List[str]) -> pd.DataFrame:
         """
-        Scale numerical features.
-        
+        Scale numerical features using standard (z-score) scaling.
+
         Args:
             df: Input DataFrame
             feature_cols: List of feature columns to scale
-            scaler_type: Type of scaler ('standard' or 'minmax')
-            
+
         Returns:
             DataFrame with scaled features
         """
         df = df.copy()
-        
+
         available_cols = [col for col in feature_cols if col in df.columns]
-        
+
         if not available_cols:
             logger.warning("No feature columns found for scaling")
             return df
-        
+
         # Handle missing values before scaling
         for col in available_cols:
             if df[col].isnull().any():
@@ -383,26 +382,21 @@ class FeatureEngineer:
                 if pd.isna(median_val):
                     median_val = 0
                 df[col] = df[col].fillna(median_val)
-        
-        if scaler_type == 'standard':
-            scaler = StandardScaler()
-        elif scaler_type == 'minmax':
-            scaler = MinMaxScaler()
-        else:
-            raise ValueError("scaler_type must be 'standard' or 'minmax'")
-        
+
+        scaler = StandardScaler()
+
         # Scale features
         df_scaled = scaler.fit_transform(df[available_cols])
         df_scaled = pd.DataFrame(df_scaled, columns=available_cols, index=df.index)
-        
+
         # Replace original columns with scaled ones
         for col in available_cols:
             df[f'{col}_scaled'] = df_scaled[col]
-        
+
         # Store scaler for later use
-        self.scalers[scaler_type] = scaler
-        
-        logger.info(f"Scaled {len(available_cols)} features using {scaler_type} scaler")
+        self.scalers['standard'] = scaler
+
+        logger.info(f"Scaled {len(available_cols)} features using standard scaler")
         return df
     
     def _is_holiday(self, dates: pd.Series) -> pd.Series:

--- a/tests/demo_feature_engineering.py
+++ b/tests/demo_feature_engineering.py
@@ -156,7 +156,7 @@ def demonstrate_feature_scaling(df, fe):
     if not numerical_cols:
         numerical_cols = [c for c in df.select_dtypes(include=[np.number]).columns if c != "date"][:4]
     print(f"📊 Scaling: {numerical_cols}")
-    result = fe.scale_features(df, numerical_cols, scaler_type="standard")
+    result = fe.scale_features(df, numerical_cols)
     scaled_cols = [c for c in result.columns if c.endswith("_scaled")]
     print(f"✨ Added {len(scaled_cols)} scaled features (mean≈0, std≈1)\n")
     return result

--- a/tests/demo_predictive_modeling.py
+++ b/tests/demo_predictive_modeling.py
@@ -120,7 +120,7 @@ def apply_feature_engineering_silently(df, fe):
             c for c in df.select_dtypes(include=[np.number]).columns if c not in exclude
         ]
         if numeric_cols:
-            df = fe.scale_features(df, numeric_cols, scaler_type="standard")
+            df = fe.scale_features(df, numeric_cols)
             print(f"   ✅ scaled {len(numeric_cols)} numeric features")
     except Exception as exc:
         print(f"   ⚠️  scaling: {exc}")


### PR DESCRIPTION
## Summary

- Return HTTP 404 with available-models list when the requested `{platform}_{content_type}` model is not loaded, instead of silently falling back to the first loaded model and returning wrong-looking-right predictions.
- Return HTTP 400 when no posts row exists for the requested prediction date, instead of constructing a synthetic row with only 6 temporal columns that mismatches the model's full feature set.
- Add `except HTTPException: raise` guard to all four endpoints (`/predict`, `/analyze`, `/repost`, `/caption`) so existing 4xx errors are no longer re-wrapped as 500.
- Prune dead `MinMaxScaler` import and the dead `"minmax"` branch in `scale_features` — the function is standard-only and the dead branch was never reachable.
- Update `tests/demo_feature_engineering.py` and `tests/demo_predictive_modeling.py` demo callers; fix stale comment in `config/config.yaml`.

## Test plan

- [ ] All 41 existing unit tests pass (`pytest` — confirmed clean locally).
- [ ] `py_compile` on all modified Python files — confirmed no syntax errors.
- [ ] No README changes needed (internal error-handling fix; no user-facing API contract, config schema, or output format changes).

Closes #27