### PR TITLE
docs: mark MLflow as scaffolded and add missing API endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ docker-run-detached:
 docker-stop:
 	docker-compose down
 
-# Run MLflow server
+# Run MLflow server (scaffolded, not yet wired — server starts but no code logs to it yet)
 run-mlflow:
 	mlflow server --host 0.0.0.0 --port 5000 --backend-store-uri sqlite:///mlflow/mlflow.db --default-artifact-root file:/mlflow
 
@@ -87,4 +87,4 @@ dev-setup: init
 	@echo "Development environment setup complete!"
 	@echo "Run 'make run-api' to start the API server"
 	@echo "Run 'make run-dashboard' to start the dashboard"
-	@echo "Run 'make run-mlflow' to start MLflow tracking server"
+	@echo "Run 'make run-mlflow' to start MLflow tracking server (scaffolded, not yet wired)"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ content-performance-predictor/
 ### Machine Learning
 - **Models:** scikit-learn, XGBoost, LightGBM, CatBoost
 - **NLP:** TextBlob
-- **Experiment Tracking:** MLflow
+- **Experiment Tracking:** MLflow *(scaffolded, not yet wired — `log_to_mlflow` is defined but never called)*
 
 ### Visualization & Dashboard
 - **Visualization:** plotly
@@ -150,8 +150,8 @@ make run-api
 # Run dashboard (in another terminal)
 make run-dashboard
 
-# Run MLflow tracking server (in another terminal)
-make run-mlflow
+# Run MLflow tracking server (scaffolded, not yet wired — server starts but no code logs to it yet)
+# make run-mlflow
 ```
 
 #### Option B: Using Docker
@@ -170,8 +170,8 @@ uvicorn src.api.prediction_api:app --host 0.0.0.0 --port 8000 --reload
 # Run dashboard
 python dash_app/app.py
 
-# Run MLflow server
-mlflow server --host 0.0.0.0 --port 5000
+# Run MLflow server (scaffolded, not yet wired — server starts but no code logs to it yet)
+# mlflow server --host 0.0.0.0 --port 5000
 ```
 
 ## 📊 Usage
@@ -187,6 +187,7 @@ The API provides the following endpoints:
 - `POST /best-times` - Get best posting times
 - `POST /platform-trends` - Get platform trends
 - `GET /models` - List available models
+- `GET /models/{model_name}` - Get model detail and summary
 
 #### Example API Usage
 


### PR DESCRIPTION
## Summary

- Mark MLflow as **scaffolded, not yet wired** in three places (Tech Stack section, Quick Start Option A, Quick Start Option C) — `log_to_mlflow` is defined in `BaseModel` but never invoked; prior wording sent readers to stand up MLflow infrastructure for a non-functional feature, undermining the repo's credibility.
- Comment out the `make run-mlflow` and bare `mlflow server` commands so new readers are not sent down a dead end; the target itself is preserved for when the code side is wired up.
- Add `GET /models/{model_name}` to the **API Endpoints** list — the route exists at `src/api/prediction_api.py:469` but was missing from the README index.
- Update Makefile comments to match the scaffolded status.

## Validation

- **3b Syntax gate:** doc-only change (README.md, Makefile comments); no Python touched.
- **3e Behavioral:** `GET /models/{model_name}` confirmed at `src/api/prediction_api.py:469`. `log_to_mlflow` confirmed defined-only at `src/models/base_model.py:278`, zero callers.
- **3f Sanity sweep:** diff covers 2 files, 8 insertions / 7 deletions, all within stated scope. No tests removed, no code changed, no dependency bumps.
- **CI:** no `.github/workflows/` — no CI to await.

Closes #41