### PR TITLE
refactor: dedup database.py and model_pipeline.py helpers

### DIFF
--- a/src/data/database.py
+++ b/src/data/database.py
@@ -26,6 +26,25 @@ class SupabaseClient:
         self.client: Client = create_client(self.url, self.key)
         logger.info("Supabase client initialized")
     
+    def _get_table_data(self, table: str, start_date: Optional[str], end_date: Optional[str]) -> pd.DataFrame:
+        try:
+            response = self.client.table(table).select("*").execute()
+            df = pd.DataFrame(response.data)
+
+            if start_date or end_date:
+                df['date'] = pd.to_datetime(df['date'])
+                if start_date:
+                    df = df[df['date'] >= pd.to_datetime(start_date)]
+                if end_date:
+                    df = df[df['date'] <= pd.to_datetime(end_date)]
+
+            logger.info(f"Loaded {len(df)} {table} records")
+            return df
+
+        except Exception as e:
+            logger.error(f"Error loading {table} data: {e}")
+            raise
+
     def get_posts_data(self, start_date: Optional[str] = None, end_date: Optional[str] = None) -> pd.DataFrame:
         """
         Load posts data from the consolidated posts table.
@@ -37,24 +56,8 @@ class SupabaseClient:
         Returns:
             DataFrame with posts data
         """
-        try:
-            response = self.client.table("posts").select("*").execute()
-            df = pd.DataFrame(response.data)
-            
-            if start_date or end_date:
-                df['date'] = pd.to_datetime(df['date'])
-                if start_date:
-                    df = df[df['date'] >= pd.to_datetime(start_date)]
-                if end_date:
-                    df = df[df['date'] <= pd.to_datetime(end_date)]
-            
-            logger.info(f"Loaded {len(df)} posts records")
-            return df
-            
-        except Exception as e:
-            logger.error(f"Error loading posts data: {e}")
-            raise
-    
+        return self._get_table_data("posts", start_date, end_date)
+
     def get_profile_data(self, start_date: Optional[str] = None, end_date: Optional[str] = None) -> pd.DataFrame:
         """
         Load profile data from the consolidated profile table.
@@ -66,23 +69,7 @@ class SupabaseClient:
         Returns:
             DataFrame with profile data
         """
-        try:
-            response = self.client.table("profile").select("*").execute()
-            df = pd.DataFrame(response.data)
-            
-            if start_date or end_date:
-                df['date'] = pd.to_datetime(df['date'])
-                if start_date:
-                    df = df[df['date'] >= pd.to_datetime(start_date)]
-                if end_date:
-                    df = df[df['date'] <= pd.to_datetime(end_date)]
-            
-            logger.info(f"Loaded {len(df)} profile records")
-            return df
-            
-        except Exception as e:
-            logger.error(f"Error loading profile data: {e}")
-            raise
+        return self._get_table_data("profile", start_date, end_date)
     
 
 def get_supabase_client() -> SupabaseClient:

--- a/src/models/model_pipeline.py
+++ b/src/models/model_pipeline.py
@@ -32,27 +32,6 @@ logger = logging.getLogger(__name__)
 _LEAKAGE_PATTERNS = ("_rolling_", "_lag_", "_scaled", "_rate", "_trend", "_diff")
 
 
-def remove_data_leakage_features(feature_cols: List[str], target_col: str) -> List[str]:
-    """Drop features derived from the target variable (data leakage).
-
-    Args:
-        feature_cols: Candidate feature column names.
-        target_col: The target column name.
-
-    Returns:
-        ``feature_cols`` with target-derived columns removed.
-    """
-    target_base = target_col.replace("_scaled", "")
-    leakage = [
-        col
-        for col in feature_cols
-        if target_base in col
-        and col != target_col
-        and any(pattern in col for pattern in _LEAKAGE_PATTERNS)
-    ]
-    return [col for col in feature_cols if col not in leakage]
-
-
 def find_leakage_features(feature_cols: List[str], target_col: str) -> List[str]:
     """Return the target-derived (leaking) features without removing them."""
     target_base = target_col.replace("_scaled", "")
@@ -63,6 +42,20 @@ def find_leakage_features(feature_cols: List[str], target_col: str) -> List[str]
         and col != target_col
         and any(pattern in col for pattern in _LEAKAGE_PATTERNS)
     ]
+
+
+def remove_data_leakage_features(feature_cols: List[str], target_col: str) -> List[str]:
+    """Drop features derived from the target variable (data leakage).
+
+    Args:
+        feature_cols: Candidate feature column names.
+        target_col: The target column name.
+
+    Returns:
+        ``feature_cols`` with target-derived columns removed.
+    """
+    leakage = set(find_leakage_features(feature_cols, target_col))
+    return [col for col in feature_cols if col not in leakage]
 
 
 def resolve_target_column(df: pd.DataFrame, target_col: str) -> str:


### PR DESCRIPTION
## Summary

- `src/data/database.py`: extracted private `_get_table_data(table, start_date, end_date)`; both `get_posts_data` and `get_profile_data` now delegate to it, eliminating the copy-paste date-filter and try/except block.
- `src/models/model_pipeline.py`: `remove_data_leakage_features` now delegates to `find_leakage_features` so the leakage-detection predicate lives in exactly one place.

Both changes are behavior-preserving.

## Test plan

- [x] `pytest tests/` — 41 passed, 0 failed

Closes #40