### PR TITLE
chore: remove dead accessors/factory/mlflow scaffolding and prune unused deps

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -82,11 +82,6 @@ dashboard:
   port: ${DASHBOARD_PORT:-8050}
   debug: ${DASHBOARD_DEBUG:-true}
 
-# MLflow Configuration
-mlflow:
-  tracking_uri: ${MLFLOW_TRACKING_URI:-http://localhost:5000}
-  experiment_name: ${MLFLOW_EXPERIMENT_NAME:-content-performance-predictor}
-
 # Logging Configuration
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Data processing and analysis
 pandas>=2.0.0
-polars>=0.20.0
 numpy>=1.24.0
 scipy>=1.10.0
 
@@ -9,22 +8,13 @@ scikit-learn>=1.3.0
 xgboost>=1.7.0
 lightgbm>=4.0.0
 catboost>=1.2.0
-torch>=2.0.0
-transformers>=4.30.0
-sentence-transformers>=2.2.0
-feature-engine>=1.6.0
 prophet>=1.1.0
-statsmodels>=0.14.0
 
 # NLP and text processing
-spacy>=3.6.0
 textblob>=0.17.0
-nltk>=3.8.0
 
 # Visualization
 plotly>=5.15.0
-seaborn>=0.12.0
-matplotlib>=3.7.0
 dash>=2.14.0
 dash-bootstrap-components>=1.5.0
 
@@ -36,9 +26,6 @@ requests>=2.31.0
 
 # Database and data storage
 supabase>=2.0.0
-psycopg2-binary>=2.9.0
-duckdb>=0.8.0
-pyarrow>=12.0.0
 
 # Experiment tracking and optimization
 mlflow>=2.6.0
@@ -49,10 +36,6 @@ pytest>=7.4.0
 black>=23.0.0
 flake8>=6.0.0
 pre-commit>=3.3.0
-
-# Documentation
-mkdocs>=1.5.0
-mkdocs-material>=9.2.0
 
 # Environment and configuration
 python-dotenv>=1.0.0

--- a/src/data/database.py
+++ b/src/data/database.py
@@ -70,8 +70,3 @@ class SupabaseClient:
             DataFrame with profile data
         """
         return self._get_table_data("profile", start_date, end_date)
-    
-
-def get_supabase_client() -> SupabaseClient:
-    """Get a Supabase client instance."""
-    return SupabaseClient()

--- a/src/models/base_model.py
+++ b/src/models/base_model.py
@@ -9,8 +9,6 @@ import os
 from abc import ABC, abstractmethod
 from sklearn.base import BaseEstimator
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
-import mlflow
-import mlflow.sklearn
 
 logger = logging.getLogger(__name__)
 
@@ -274,48 +272,7 @@ class BaseModel(ABC, BaseEstimator):
 
         logger.info(f"Model loaded from {filepath}")
         return instance
-    
-    def log_to_mlflow(self, experiment_name: str = None) -> None:
-        """
-        Log model and metrics to MLflow.
-        
-        Args:
-            experiment_name: MLflow experiment name
-        """
-        if not self.is_fitted:
-            logger.warning("Model not fitted, skipping MLflow logging")
-            return
-        
-        try:
-            if experiment_name:
-                mlflow.set_experiment(experiment_name)
-            
-            with mlflow.start_run():
-                # Log model
-                mlflow.sklearn.log_model(self.model, self.model_name)
-                
-                # Log parameters
-                if hasattr(self.model, 'get_params'):
-                    mlflow.log_params(self.model.get_params())
-                
-                # Log metrics
-                if self.metrics:
-                    mlflow.log_metrics(self.metrics)
-                
-                # Log feature importance
-                if self.feature_importance:
-                    importance_df = pd.DataFrame(
-                        list(self.feature_importance.items()),
-                        columns=['feature', 'importance']
-                    ).sort_values('importance', ascending=False)
-                    
-                    mlflow.log_artifact(importance_df.to_csv(index=False), "feature_importance.csv")
-                
-                logger.info(f"Model logged to MLflow experiment: {experiment_name}")
-                
-        except Exception as e:
-            logger.error(f"Error logging to MLflow: {e}")
-    
+
     def get_model_summary(self) -> Dict[str, Any]:
         """
         Get a summary of the model.

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -93,33 +93,9 @@ class Config:
 
         return value
 
-    def get_supabase_config(self) -> Dict[str, str]:
-        """Get Supabase configuration."""
-        return self.get("data.supabase", {})
-
-    def get_api_config(self) -> Dict[str, Any]:
-        """Get API configuration."""
-        return self.get("api", {})
-
-    def get_dashboard_config(self) -> Dict[str, Any]:
-        """Get dashboard configuration."""
-        return self.get("dashboard", {})
-
-    def get_mlflow_config(self) -> Dict[str, str]:
-        """Get MLflow configuration."""
-        return self.get("mlflow", {})
-
     def get_paths(self) -> Dict[str, str]:
         """Get paths configuration."""
         return self.get("paths", {})
-
-    def get_model_config(self) -> Dict[str, Any]:
-        """Get model configuration."""
-        return self.get("models", {})
-
-    def get_feature_config(self) -> Dict[str, Any]:
-        """Get feature engineering configuration."""
-        return self.get("features", {})
 
 
 # Global configuration instance


### PR DESCRIPTION
## Summary

- Deleted 6 typed config accessor methods (`get_supabase_config`, `get_api_config`, `get_dashboard_config`, `get_mlflow_config`, `get_model_config`, `get_feature_config`) from `src/utils/config.py` — only `Config.get()` and `Config.get_paths()` are actually called anywhere in the repo.
- Removed the dead module-level `get_supabase_client()` factory from `src/data/database.py` — callers use `SupabaseClient()` directly.
- Dropped `log_to_mlflow()` and its `mlflow`/`mlflow.sklearn` imports from `src/models/base_model.py`; removed the `mlflow:` block from `config/config.yaml` — MLflow is scaffolded but never wired into the pipeline.
- Pruned 15 unimported heavy deps from `requirements.txt`: `torch`, `transformers`, `sentence-transformers`, `statsmodels`, `spacy`, `nltk`, `seaborn`, `matplotlib`, `duckdb`, `pyarrow`, `polars`, `feature-engine`, `psycopg2-binary`, `mkdocs`, `mkdocs-material`.
- **Kept** `prophet` + `optuna` — mapped to open enhancements #20 / #21.
- **Kept** `mlflow>=2.6.0` dep — `make run-mlflow` + `docker-compose` still reference the server; code removed but dep retained intentionally.

## Test plan

- [x] `pytest tests/` — 41 passed, 0 failed

Closes #39