### PR TITLE
docs: fix stale log_to_mlflow reference in tech-stack section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ content-performance-predictor/
 ### Machine Learning
 - **Models:** scikit-learn, XGBoost, LightGBM, CatBoost
 - **NLP:** TextBlob
-- **Experiment Tracking:** MLflow *(scaffolded, not yet wired — `log_to_mlflow` is defined but never called)*
+- **Experiment Tracking:** MLflow *(scaffolded, not yet wired — server starts but no code logs to it yet)*
 
 ### Visualization & Dashboard
 - **Visualization:** plotly


### PR DESCRIPTION
## Summary

- README:71 referenced `log_to_mlflow()` which was deleted in 45f0e14 (Closes #39)
- Replaces the stale function-name mention with the server-oriented framing already used consistently at README:153 and README:173: *"server starts but no code logs to it yet"*
- The broader MLflow-scaffolded status remains accurate; only the specific function reference was stale

## Validation

- Diff is docs-only (one line in `README.md`); no Python changed
- No `.github/workflows/` directory exists — no CI to run
- Confirmed three MLflow mentions in README are now consistent
- `git diff main...HEAD` shows exactly one-line change, no unintended scope

Closes #46