### PR TITLE
fix: build /predict model_key with model_type so it matches train-time keys

### DIFF
--- a/src/api/prediction_api.py
+++ b/src/api/prediction_api.py
@@ -48,6 +48,14 @@ class PredictionRequest(BaseModel):
     platform: str = Field(..., description="Platform (linkedin, instagram, twitter, substack, threads)")
     content_type: str = Field(..., description="Content type (no_video, video)")
     date: date = Field(..., description="Date for prediction")
+    model_type: str = Field(
+        default="xgboost",
+        description=(
+            "Model type to predict with (random_forest, xgboost, lightgbm, "
+            "catboost, linear_regression). Must match a trained model — train "
+            "saves under {platform}_{content_type}_{model_type}."
+        ),
+    )
     features: Optional[Dict[str, Any]] = Field(default=None, description="Additional features")
     
 class PredictionResponse(BaseModel):
@@ -228,15 +236,18 @@ async def predict_engagement(request: PredictionRequest):
             for key, value in request.features.items():
                 prediction_data[key] = value
         
-        # Select the model trained for this platform/content type. Never silently
+        # Select the model trained for this platform/content type/model type.
+        # The key must match exactly how the CLI `train` command saves models
+        # (src/cli.py): {platform}_{content_type}_{model_type}. Never silently
         # substitute an unrelated model — that returns wrong-looking-right output
         # under the caller's requested key, which is worse than failing.
-        model_key = f"{request.platform}_{request.content_type}"
+        model_key = f"{request.platform}_{request.content_type}_{request.model_type}"
         if model_key not in models:
             raise HTTPException(
                 status_code=404,
                 detail=(
-                    f"No trained model for {request.platform}/{request.content_type}. "
+                    f"No trained model for {request.platform}/{request.content_type}"
+                    f"/{request.model_type}. "
                     f"Available models: {sorted(models.keys())}"
                 ),
             )


### PR DESCRIPTION
## Summary

- `PredictionRequest` gains an optional `model_type` field (default `xgboost`) mirroring the three-part key the CLI `train` command uses when saving models: `{platform}_{content_type}_{model_type}`
- `/predict` now builds the full key at lookup time, ending the HTTP 404 that made the headline Predict flow non-functional for every CLI-trained model
- The 404 error message surfaces the requested `model_type` alongside all available keys to aid diagnosis when a model genuinely hasn't been trained yet
- Callers that omit `model_type` get the `xgboost` default, so existing requests that were previously always-failing now resolve correctly with no call-site changes

## Validation

- `pytest tests/` — 41 passed, 0 failed
- No `.github/workflows/` directory — no CI to run
- UX surface: `SPEC_APPLIES=no TOUCHED=no` — no UX gate

Closes #45