### PR TITLE
chore: trim config.yaml to keys the code actually reads (#47)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,97 +1,32 @@
 # Content Performance Predictor Configuration
+#
+# This file lists ONLY the keys the application actually reads via
+# `src/utils/config.py` (`Config.get` / `Config.get_paths`). Adding a key here
+# does nothing until code reads it — so the previously-unread sections were
+# removed (see #47).
+#
+# What the code honors today:
+#   - data.platforms / data.content_types  -> src/constants.py
+#   - paths.models                          -> src/cli.py (Config.get_paths()['models'])
+#
+# Everything else the app needs is read directly from environment variables or
+# hardcoded in code, NOT from this file:
+#   - Supabase URL/keys, API_*, DASHBOARD_*, LOG_* -> os.getenv (.env / .env.example)
+#   - model hyperparameters                        -> src/models/prediction_models.py
 
 # Data Configuration
 data:
-  supabase:
-    url: ${SUPABASE_URL}
-    key: ${SUPABASE_KEY}
-    service_role_key: ${SUPABASE_SERVICE_ROLE_KEY}
-  
   platforms:
     - linkedin
     - instagram
     - twitter
     - substack
     - threads
-  
+
   content_types:
     - no_video
     - video
 
-# Model Configuration
-models:
-  types:
-    - random_forest
-    - xgboost
-    - lightgbm
-    - catboost
-    - linear_regression
-    - ridge
-    - svr
-    - mlp
-  
-  default_params:
-    random_forest:
-      n_estimators: 100
-      max_depth: 10
-      random_state: 42
-      n_jobs: -1
-    
-    xgboost:
-      n_estimators: 100
-      max_depth: 6
-      learning_rate: 0.1
-      random_state: 42
-      n_jobs: -1
-    
-    lightgbm:
-      n_estimators: 100
-      max_depth: 6
-      learning_rate: 0.1
-      random_state: 42
-      n_jobs: -1
-    
-    catboost:
-      iterations: 100
-      depth: 6
-      learning_rate: 0.1
-      random_state: 42
-      verbose: false
-
-# Feature Engineering Configuration
-features:
-  temporal:
-    lags: [1, 3, 7, 14, 30]
-    window_sizes: [7, 14, 30]
-  
-  scaling:
-    method: standard  # z-score (StandardScaler)
-  
-  importance_threshold: 0.01
-
-# API Configuration
-api:
-  host: ${API_HOST:-0.0.0.0}
-  port: ${API_PORT:-8000}
-  reload: ${API_RELOAD:-true}
-  cors_origins: ["*"]
-
-# Dashboard Configuration
-dashboard:
-  host: ${DASHBOARD_HOST:-0.0.0.0}
-  port: ${DASHBOARD_PORT:-8050}
-  debug: ${DASHBOARD_DEBUG:-true}
-
-# Logging Configuration
-logging:
-  level: ${LOG_LEVEL:-INFO}
-  file: ${LOG_FILE:-./logs/app.log}
-  format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-
 # Paths
 paths:
   models: ${MODEL_PATH:-./models}
-  data: ${DATA_PATH:-./data}
-  features: ${FEATURE_STORE_PATH:-./data/features}
-  experiments: ${EXPERIMENT_PATH:-./mlflow}
-  logs: ${LOG_PATH:-./logs}


### PR DESCRIPTION
## Summary

Resolves the `stale` audit finding in #47. `config/config.yaml` presented model hyperparameters plus API / dashboard / logging / Supabase settings as tunable knobs, but the application only ever reads **three** keys. Editing anything else was a silent no-op — latent "lying config".

Per the issue's primary suggested fix (conservative, minimal-risk), this **trims** the file to only the keys the code honors rather than wiring the dead keys through `Config` (the latter would be a redesign, out of scope).

**Kept** (verified consumed):
- `data.platforms`, `data.content_types` — `src/constants.py`
- `paths.models` — `src/cli.py` (`Config.get_paths()['models']`)

**Removed** (verified never read — re-grepped every key across the repo, incl. non-Python files):
- `models.types`, `models.default_params`, `features.*`, `api.*`, `dashboard.*`, `logging.*`, `data.supabase.*`, `paths.{data,features,experiments,logs}`

`models.default_params` specifically duplicated the hyperparameters hardcoded in `src/models/prediction_models.py` `_create_model` (random_forest n_estimators=100/max_depth=10, xgboost/lightgbm max_depth=6/lr=0.1, catboost, etc.) — two sources of truth that silently drift; the YAML block was never read, so it is dropped. Those settings continue to live where the code reads them: env vars (`os.getenv` for Supabase/API/dashboard/logging) and hardcoded defaults (hyperparameters). A header comment now documents the read-keys contract.

Nothing load-bearing was trimmed.

## Validation

- **Re-grep (hard gate):** confirmed every removed key has zero readers anywhere — only `Config.get`/`get_paths` callers are `src/constants.py` (`data.platforms`, `data.content_types`) and `src/cli.py` (`paths.models`). `tests/test_config.py` references to `data.supabase.url`/`api.host` use their own self-contained tmp_path YAML fixtures, not the repo file.
- **Behavioral probe:** loaded the trimmed file through `Config` — `data.platforms`, `data.content_types`, and `paths.models` all resolve correctly; `constants.PLATFORMS`/`CONTENT_TYPES` still derive from config; removed keys cleanly return defaults (no crash).
- **YAML parse:** `yaml.safe_load` clean; top-level keys now exactly `data`, `paths`.
- **Test suite:** `pytest -q` → **41 passed**, 0 failures, 0 skips (matches pre-change baseline; the 2 warnings are pre-existing numpy divide warnings, unrelated).
- **Diff sweep:** single file changed (`config/config.yaml`), only the intended removals.

Closes #47